### PR TITLE
Improve migration support using `CREATE INDEX ASYNC`

### DIFF
--- a/aurora_dsql_django/tests/unit/test_schema.py
+++ b/aurora_dsql_django/tests/unit/test_schema.py
@@ -13,6 +13,10 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
     def test_sql_attributes(self):
         self.assertEqual(self.schema_editor.sql_delete_fk, "")
         self.assertEqual(self.schema_editor.sql_create_pk, "")
+        self.assertEqual(self.schema_editor.sql_create_index,
+                         "CREATE INDEX ASYNC %(name)s ON %(table)s%(using)s (%(columns)s)%(include)s%(extra)s%(condition)s")
+        self.assertEqual(self.schema_editor.sql_create_unique,
+                         "CREATE UNIQUE INDEX ASYNC %(name)s ON %(table)s (%(columns)s)")
         self.assertEqual(
             self.schema_editor.sql_delete_unique,
             "DROP INDEX %(name)s CASCADE")
@@ -20,7 +24,6 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
             self.schema_editor.sql_update_with_default,
             "UPDATE %(table)s SET %(column)s = %(default)s WHERE %(column)s IS NULL"
         )
-        self.assertEqual(self.schema_editor.sql_create_unique, "")
         self.assertEqual(self.schema_editor.sql_create_fk, "")
         self.assertEqual(self.schema_editor.sql_create_check, "")
         self.assertEqual(self.schema_editor.sql_delete_check, "")


### PR DESCRIPTION
This PR improves migration support by using the `CREATE INDEX ASYNC` syntax in `schema.py`.

Changes extracted and modified from #46.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

The changes are detailed below.

### `sql_create_index`

Previously defined as:

```python
sql_create_index = (
    "CREATE INDEX %(name)s ON %(table)s%(using)s "
    "(%(columns)s)%(include)s%(extra)s%(condition)s"
)
```

Now defined as:

```python
sql_create_index = (
    "CREATE INDEX ASYNC %(name)s ON %(table)s%(using)s "
    "(%(columns)s)%(include)s%(extra)s%(condition)s"
)
```

This matches the syntax defined by [Asynchronous indexes in Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-create-index-async.html).

### `sql_create_unique`

Previously defined as:

```python
sql_create_unique = (
    "ALTER TABLE %(table)s ADD CONSTRAINT %(name)s "
    "UNIQUE%(nulls_distinct)s (%(columns)s)%(deferrable)s"
)
```

Now defined as:

```python
sql_create_unique = "CREATE UNIQUE INDEX ASYNC %(name)s ON %(table)s (%(columns)s)"
```

This avoids the `ALTER TABLE ... ADD CONSTRAINT` syntax which is not supported by DSQL according to [Supported subsets of SQL commands in Aurora DSQL](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-sql-subsets.html#alter-table-syntax-support).

### General cleanup

As part of this change I added some more documentation, and reorganized the position of a few definitions to better isolate concepts. This will make upcoming changes simpler too thanks to the improved consistency.
