### PR TITLE
Remove unnecessary foreign key operation overrides

### DIFF
--- a/aurora_dsql_django/schema.py
+++ b/aurora_dsql_django/schema.py
@@ -49,8 +49,6 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
 
     # These "ALTER TABLE" operations are not supported.
     sql_create_pk = ""
-    sql_create_fk = ""
-    sql_delete_fk = ""
     sql_create_check = ""
     sql_delete_check = ""
     sql_delete_constraint = ""

--- a/aurora_dsql_django/tests/unit/test_schema.py
+++ b/aurora_dsql_django/tests/unit/test_schema.py
@@ -11,7 +11,6 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
         self.schema_editor = DatabaseSchemaEditor(self.connection)
 
     def test_sql_attributes(self):
-        self.assertEqual(self.schema_editor.sql_delete_fk, "")
         self.assertEqual(self.schema_editor.sql_create_pk, "")
         self.assertEqual(self.schema_editor.sql_create_index,
                          "CREATE INDEX ASYNC %(name)s ON %(table)s%(using)s (%(columns)s)%(include)s%(extra)s%(condition)s")
@@ -24,7 +23,6 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
             self.schema_editor.sql_update_with_default,
             "UPDATE %(table)s SET %(column)s = %(default)s WHERE %(column)s IS NULL"
         )
-        self.assertEqual(self.schema_editor.sql_create_fk, "")
         self.assertEqual(self.schema_editor.sql_create_check, "")
         self.assertEqual(self.schema_editor.sql_delete_check, "")
         self.assertEqual(self.schema_editor.sql_delete_constraint, "")

--- a/aurora_dsql_django/tests/unit/test_wrapper.py
+++ b/aurora_dsql_django/tests/unit/test_wrapper.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import django
+from django.conf import settings
+from django.db import models
+from aurora_dsql_django.base import DatabaseWrapper
+from aurora_dsql_django.features import DatabaseFeatures
+from aurora_dsql_django.schema import DatabaseSchemaEditor
+
+if not settings.configured:
+    settings.configure(
+        INSTALLED_APPS=['django.contrib.contenttypes'],
+        DATABASES={'default': {'ENGINE': 'aurora_dsql_django'}},
+        USE_TZ=True,
+    )
+    django.setup()
+
+
+class TestWrapper(unittest.TestCase):
+    """Test Aurora DSQL wrapper behavior when all parts are working together"""
+
+    def setUp(self):
+        self.connection = DatabaseWrapper({})
+        self.connection.connection = MagicMock()
+        self.connection.connection.encoding = 'utf8'
+
+        # Configure mock to use real components.
+        self.connection.features = DatabaseFeatures(self.connection)
+        self.schema_editor = DatabaseSchemaEditor(self.connection)
+
+    def test_foreign_key_sql_generation(self):
+        """Ensure foreign key SQL is not generated when the feature is disabled"""
+
+        class ParentModel(models.Model):
+            class Meta:
+                app_label = 'test_app'
+
+        class ChildModel(models.Model):
+            parent = models.ForeignKey(ParentModel, on_delete=models.CASCADE)
+
+            class Meta:
+                app_label = 'test_app'
+
+        # Mock execute to capture SQL without actually running it.
+        with patch.object(self.schema_editor, 'execute'):
+            with self.schema_editor:
+                self.schema_editor.create_model(ChildModel)
+
+                # Check that no foreign key SQL was deferred.
+                foreign_key_statements = [sql for sql in self.schema_editor.deferred_sql if 'FOREIGN KEY' in str(sql)]
+                self.assertListEqual([], foreign_key_statements, "Should not generate foreign key SQL")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR removes the unnecessary `sql_create_fk` and `sql_delete_fk` configurations.

Since we are already configuring `supports_foreign_keys = False` in `features.py`, the base class will skip foreign key operations. I have added a new unit test which integrates components of the wrapper to confirm this. The new test will provide a place for future tests which require wider scope.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
