### PR TITLE
Disable check constraints via feature flag

### DIFF
--- a/aurora_dsql_django/features.py
+++ b/aurora_dsql_django/features.py
@@ -31,8 +31,9 @@ class DatabaseFeatures(features.DatabaseFeatures):
     # at the end of each save operation?
     supports_forward_references = True
 
-    # Does it support foreign keys?
     supports_foreign_keys = False
+
+    supports_table_check_constraints = False
 
     # Can it create foreign key constraints inline when adding columns?
     can_create_inline_fk = False

--- a/aurora_dsql_django/schema.py
+++ b/aurora_dsql_django/schema.py
@@ -49,8 +49,6 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
 
     # These "ALTER TABLE" operations are not supported.
     sql_create_pk = ""
-    sql_create_check = ""
-    sql_delete_check = ""
     sql_delete_constraint = ""
     sql_delete_column = ""
 
@@ -67,12 +65,19 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     def add_index(self, model, index, concurrently=False):
         if index.contains_expressions and not self.connection.features.supports_expression_indexes:
             return None
-        super().add_index(model, index, concurrently)
+        return super().add_index(model, index, concurrently)
 
     def remove_index(self, model, index, concurrently=False):
         if index.contains_expressions and not self.connection.features.supports_expression_indexes:
             return None
-        super().remove_index(model, index, concurrently)
+        return super().remove_index(model, index, concurrently)
+
+    def _check_sql(self, name, check):
+        # There is no feature check in the upstream implementation when creating
+        # a model, so we add our own check.
+        if not self.connection.features.supports_table_check_constraints:
+            return None
+        return super()._check_sql(name, check)
 
     def _index_columns(self, table, columns, col_suffixes, opclasses):
         # Aurora DSQL doesn't support PostgreSQL opclasses.

--- a/aurora_dsql_django/schema.py
+++ b/aurora_dsql_django/schema.py
@@ -19,6 +19,7 @@ for Aurora DSQL.
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.backends.postgresql import schema
+from django.db.models import CheckConstraint
 
 
 class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
@@ -64,13 +65,13 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
 
     def add_index(self, model, index, concurrently=False):
         if index.contains_expressions and not self.connection.features.supports_expression_indexes:
-            return None
-        return super().add_index(model, index, concurrently)
+            return
+        super().add_index(model, index, concurrently)
 
     def remove_index(self, model, index, concurrently=False):
         if index.contains_expressions and not self.connection.features.supports_expression_indexes:
-            return None
-        return super().remove_index(model, index, concurrently)
+            return
+        super().remove_index(model, index, concurrently)
 
     def _check_sql(self, name, check):
         # There is no feature check in the upstream implementation when creating
@@ -78,6 +79,18 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         if not self.connection.features.supports_table_check_constraints:
             return None
         return super()._check_sql(name, check)
+
+    def add_constraint(self, model, constraint):
+        # Older versions of Django don't reference supports_table_check_constraints, so we add this as a backup.
+        if isinstance(constraint, CheckConstraint) and not self.connection.features.supports_table_check_constraints:
+            return
+        super().add_constraint(model, constraint)
+
+    def remove_constraint(self, model, constraint):
+        # Older versions of Django don't reference supports_table_check_constraints, so we add this as a backup.
+        if isinstance(constraint, CheckConstraint) and not self.connection.features.supports_table_check_constraints:
+            return
+        super().remove_constraint(model, constraint)
 
     def _index_columns(self, table, columns, col_suffixes, opclasses):
         # Aurora DSQL doesn't support PostgreSQL opclasses.

--- a/aurora_dsql_django/tests/unit/test_features.py
+++ b/aurora_dsql_django/tests/unit/test_features.py
@@ -18,6 +18,9 @@ class TestDatabaseFeatures(unittest.TestCase):
     def test_supports_foreign_keys(self):
         self.assertFalse(self.features.supports_foreign_keys)
 
+    def test_supports_check_constraints(self):
+        self.assertFalse(self.features.supports_table_check_constraints)
+
     def test_can_create_inline_fk(self):
         self.assertFalse(self.features.can_create_inline_fk)
 

--- a/aurora_dsql_django/tests/unit/test_schema.py
+++ b/aurora_dsql_django/tests/unit/test_schema.py
@@ -23,8 +23,6 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
             self.schema_editor.sql_update_with_default,
             "UPDATE %(table)s SET %(column)s = %(default)s WHERE %(column)s IS NULL"
         )
-        self.assertEqual(self.schema_editor.sql_create_check, "")
-        self.assertEqual(self.schema_editor.sql_delete_check, "")
         self.assertEqual(self.schema_editor.sql_delete_constraint, "")
         self.assertEqual(self.schema_editor.sql_delete_column, "")
 
@@ -92,6 +90,25 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
         result = self.schema_editor._create_like_index_sql(model, field)
 
         self.assertIsNone(result)
+
+    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor._check_sql')
+    def test_check_sql_feature_disabled(self, mock_super_check_sql):
+        self.connection.features.supports_table_check_constraints = False
+        
+        result = self.schema_editor._check_sql("test_check", "age >= 0")
+        
+        self.assertIsNone(result)
+        mock_super_check_sql.assert_not_called()
+
+    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor._check_sql')
+    def test_check_sql_feature_enabled(self, mock_super_check_sql):
+        self.connection.features.supports_table_check_constraints = True
+        mock_super_check_sql.return_value = "CHECK (age >= 0)"
+        
+        result = self.schema_editor._check_sql("test_check", "age >= 0")
+        
+        mock_super_check_sql.assert_called_once_with("test_check", "age >= 0")
+        self.assertEqual(result, "CHECK (age >= 0)")
 
 
 if __name__ == '__main__':

--- a/aurora_dsql_django/tests/unit/test_schema.py
+++ b/aurora_dsql_django/tests/unit/test_schema.py
@@ -1,7 +1,12 @@
 import unittest
 from unittest.mock import patch, MagicMock
-from aurora_dsql_django.schema import DatabaseSchemaEditor
+
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.models.constraints import UniqueConstraint
+from django.db.models.query_utils import Q
+
+from aurora_dsql_django.schema import DatabaseSchemaEditor
+from aurora_dsql_django.tests.utils import create_check_constraint
 
 
 class TestDatabaseSchemaEditor(unittest.TestCase):
@@ -109,6 +114,68 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
         
         mock_super_check_sql.assert_called_once_with("test_check", "age >= 0")
         self.assertEqual(result, "CHECK (age >= 0)")
+
+    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint')
+    def test_add_constraint_check_disabled(self, mock_super_add_constraint):
+        model = MagicMock()
+        constraint = create_check_constraint(Q(age__gte=0), 'age_check')
+        self.connection.features.supports_table_check_constraints = False
+        
+        result = self.schema_editor.add_constraint(model, constraint)
+        
+        self.assertIsNone(result)
+        mock_super_add_constraint.assert_not_called()
+
+    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint')
+    def test_add_constraint_check_enabled(self, mock_super_add_constraint):
+        model = MagicMock()
+        constraint = create_check_constraint(Q(age__gte=0), 'age_check')
+        self.connection.features.supports_table_check_constraints = True
+        
+        self.schema_editor.add_constraint(model, constraint)
+        
+        mock_super_add_constraint.assert_called_once_with(model, constraint)
+
+    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint')
+    def test_add_constraint_non_check(self, mock_super_add_constraint):
+        model = MagicMock()
+        constraint = UniqueConstraint(fields=['name'], name='unique_name')
+        self.connection.features.supports_table_check_constraints = False
+        
+        self.schema_editor.add_constraint(model, constraint)
+        
+        mock_super_add_constraint.assert_called_once_with(model, constraint)
+
+    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_constraint')
+    def test_remove_constraint_check_disabled(self, mock_super_remove_constraint):
+        model = MagicMock()
+        constraint = create_check_constraint(Q(age__gte=0), 'age_check')
+        self.connection.features.supports_table_check_constraints = False
+        
+        result = self.schema_editor.remove_constraint(model, constraint)
+        
+        self.assertIsNone(result)
+        mock_super_remove_constraint.assert_not_called()
+
+    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_constraint')
+    def test_remove_constraint_check_enabled(self, mock_super_remove_constraint):
+        model = MagicMock()
+        constraint = create_check_constraint(Q(age__gte=0), 'age_check')
+        self.connection.features.supports_table_check_constraints = True
+        
+        self.schema_editor.remove_constraint(model, constraint)
+        
+        mock_super_remove_constraint.assert_called_once_with(model, constraint)
+
+    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_constraint')
+    def test_remove_constraint_non_check(self, mock_super_remove_constraint):
+        model = MagicMock()
+        constraint = UniqueConstraint(fields=['name'], name='unique_name')
+        self.connection.features.supports_table_check_constraints = False
+        
+        self.schema_editor.remove_constraint(model, constraint)
+        
+        mock_super_remove_constraint.assert_called_once_with(model, constraint)
 
 
 if __name__ == '__main__':

--- a/aurora_dsql_django/tests/unit/test_wrapper.py
+++ b/aurora_dsql_django/tests/unit/test_wrapper.py
@@ -7,6 +7,7 @@ from django.db.models import CheckConstraint, Q
 from aurora_dsql_django.base import DatabaseWrapper
 from aurora_dsql_django.features import DatabaseFeatures
 from aurora_dsql_django.schema import DatabaseSchemaEditor
+from aurora_dsql_django.tests.utils import create_check_constraint
 
 if not settings.configured:
     settings.configure(
@@ -87,7 +88,7 @@ class TestWrapper(unittest.TestCase):
             class Meta:
                 app_label = 'test_app'
                 constraints = [
-                    CheckConstraint(condition=Q(age__gte=0), name='age_gte_0')
+                    create_check_constraint(Q(age__gte=0), 'age_gte_0')
                 ]
 
         def operation():
@@ -109,7 +110,7 @@ class TestWrapper(unittest.TestCase):
             class Meta:
                 app_label = 'test_app'
 
-        constraint = CheckConstraint(condition=Q(age__gte=0), name='age_gte_0')
+        constraint = create_check_constraint(Q(age__gte=0), 'age_gte_0')
 
         def operation():
             self.schema_editor.add_constraint(AddCheckConstraintModel, constraint)
@@ -129,7 +130,7 @@ class TestWrapper(unittest.TestCase):
             class Meta:
                 app_label = 'test_app'
 
-        constraint = CheckConstraint(condition=Q(age__gte=0), name='age_gte_0')
+        constraint = create_check_constraint(Q(age__gte=0), 'age_gte_0')
 
         def operation():
             self.schema_editor.remove_constraint(RemoveCheckConstraintModel, constraint)

--- a/aurora_dsql_django/tests/unit/test_wrapper.py
+++ b/aurora_dsql_django/tests/unit/test_wrapper.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import django
 from django.conf import settings
 from django.db import models
+from django.db.models import CheckConstraint, Q
 from aurora_dsql_django.base import DatabaseWrapper
 from aurora_dsql_django.features import DatabaseFeatures
 from aurora_dsql_django.schema import DatabaseSchemaEditor
@@ -16,20 +17,46 @@ if not settings.configured:
     django.setup()
 
 
+def simple_quote_value(value):
+    return f"'{value}'"
+
+
 class TestWrapper(unittest.TestCase):
     """Test Aurora DSQL wrapper behavior when all parts are working together"""
 
     def setUp(self):
         self.connection = DatabaseWrapper({})
         self.connection.connection = MagicMock()
-        self.connection.connection.encoding = 'utf8'
 
         # Configure mock to use real components.
         self.connection.features = DatabaseFeatures(self.connection)
         self.schema_editor = DatabaseSchemaEditor(self.connection)
 
-    def test_foreign_key_sql_generation(self):
-        """Ensure foreign key SQL is not generated when the feature is disabled"""
+    def _assert_sql_not_generated(self, operation_func, sql_patterns, message):
+        """Helper method to verify SQL patterns are not generated"""
+        executed_sql = []
+
+        def mock_execute(sql, params=None):
+            executed_sql.append((sql, params))
+
+        # Capture SQL statements without running anything against a real DB.
+        execute_patch = patch.object(self.schema_editor, 'execute', side_effect=mock_execute)
+
+        # Work around issue caused by missing encoding configuration in test environment.
+        quote_patch = patch.object(self.schema_editor, 'quote_value', side_effect=simple_quote_value)
+
+        with execute_patch, quote_patch:
+            operation_func()
+
+        all_sql = [str(sql) for sql, _ in executed_sql]
+        if hasattr(self.schema_editor, 'deferred_sql'):
+            all_sql += [str(sql) for sql in self.schema_editor.deferred_sql]
+
+        matching_statements = [sql for sql in all_sql if any(pattern in sql for pattern in sql_patterns)]
+        self.assertListEqual([], matching_statements, message)
+
+    def test_foreign_key_operations_ignored(self):
+        """Ensure foreign key constraint operations are ignored for model creation when the feature is disabled"""
 
         class ParentModel(models.Model):
             class Meta:
@@ -41,14 +68,77 @@ class TestWrapper(unittest.TestCase):
             class Meta:
                 app_label = 'test_app'
 
-        # Mock execute to capture SQL without actually running it.
-        with patch.object(self.schema_editor, 'execute'):
+        def operation():
             with self.schema_editor:
                 self.schema_editor.create_model(ChildModel)
 
-                # Check that no foreign key SQL was deferred.
-                foreign_key_statements = [sql for sql in self.schema_editor.deferred_sql if 'FOREIGN KEY' in str(sql)]
-                self.assertListEqual([], foreign_key_statements, "Should not generate foreign key SQL")
+        self._assert_sql_not_generated(
+            operation,
+            ['FOREIGN KEY', 'REFERENCES'],
+            "Should not generate foreign key SQL"
+        )
+
+    def test_check_constraint_create_model_ignored(self):
+        """Ensure check constraint operations are ignored for model creation when the feature is disabled"""
+
+        class CheckConstraintModel(models.Model):
+            age = models.IntegerField()
+
+            class Meta:
+                app_label = 'test_app'
+                constraints = [
+                    CheckConstraint(condition=Q(age__gte=0), name='age_gte_0')
+                ]
+
+        def operation():
+            with self.schema_editor:
+                self.schema_editor.create_model(CheckConstraintModel)
+
+        self._assert_sql_not_generated(
+            operation,
+            ['CHECK'],
+            "Should not generate check constraint SQL"
+        )
+
+    def test_check_constraint_add_constraint_ignored(self):
+        """Ensure add_constraint operations ignore check constraints when the feature is disabled"""
+
+        class AddCheckConstraintModel(models.Model):
+            age = models.IntegerField()
+
+            class Meta:
+                app_label = 'test_app'
+
+        constraint = CheckConstraint(condition=Q(age__gte=0), name='age_gte_0')
+
+        def operation():
+            self.schema_editor.add_constraint(AddCheckConstraintModel, constraint)
+
+        self._assert_sql_not_generated(
+            operation,
+            ['CHECK'],
+            "Should not execute check constraint SQL"
+        )
+
+    def test_check_constraint_remove_constraint_ignored(self):
+        """Ensure remove_constraint operations ignore check constraints when the feature is disabled"""
+
+        class RemoveCheckConstraintModel(models.Model):
+            age = models.IntegerField()
+
+            class Meta:
+                app_label = 'test_app'
+
+        constraint = CheckConstraint(condition=Q(age__gte=0), name='age_gte_0')
+
+        def operation():
+            self.schema_editor.remove_constraint(RemoveCheckConstraintModel, constraint)
+
+        self._assert_sql_not_generated(
+            operation,
+            ['CONSTRAINT'],
+            "Should not execute check constraint removal SQL"
+        )
 
 
 if __name__ == '__main__':

--- a/aurora_dsql_django/tests/utils.py
+++ b/aurora_dsql_django/tests/utils.py
@@ -1,0 +1,13 @@
+"""Shared test utilities for Aurora DSQL Django tests."""
+
+import django
+from django.db.models import CheckConstraint
+
+
+# noinspection PyArgumentList
+def create_check_constraint(condition, name):
+    """Create CheckConstraint with Django version compatibility"""
+    if django.VERSION >= (5, 0):
+        return CheckConstraint(condition=condition, name=name)
+    else:
+        return CheckConstraint(check=condition, name=name)


### PR DESCRIPTION
This PR adds the `supports_table_check_constraints = False` configuration, to skip any check constraints in migrated models.

Based on testing, I also defined an override for `_check_sql`, as some code paths do not have an explicit check against `supports_table_check_constraints` in the base class.

The tests validate that any check constraints in model definitions are ignored, so as not to interrupt migrations with unsupported features. The core model will still be created without the check constraints. This was the intention of the previous code, but the empty queries defined by the `schema.py` provided incomplete coverage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
