### PR TITLE
Clean up expression index handling

### DIFF
--- a/aurora_dsql_django/features.py
+++ b/aurora_dsql_django/features.py
@@ -54,8 +54,9 @@ class DatabaseFeatures(features.DatabaseFeatures):
     # Can the database introspect materialized views?
     can_introspect_materialized_views = False
 
-    # Can the database rename an index?
     can_rename_index = True
+
+    supports_expression_indexes = False
 
     # Does the database use savepoints for nested transactions?
     uses_savepoints = False

--- a/aurora_dsql_django/features.py
+++ b/aurora_dsql_django/features.py
@@ -54,6 +54,7 @@ class DatabaseFeatures(features.DatabaseFeatures):
     # Can the database introspect materialized views?
     can_introspect_materialized_views = False
 
+    # Can the database rename an index?
     can_rename_index = True
 
     supports_expression_indexes = False

--- a/aurora_dsql_django/tests/unit/test_features.py
+++ b/aurora_dsql_django/tests/unit/test_features.py
@@ -48,6 +48,9 @@ class TestDatabaseFeatures(unittest.TestCase):
     def test_can_rename_index(self):
         self.assertTrue(self.features.can_rename_index)
 
+    def test_supports_expression_indexes(self):
+        self.assertFalse(self.features.supports_expression_indexes)
+
     def test_inheritance(self):
         from django.db.backends.postgresql.features import DatabaseFeatures as PostgreSQLDatabaseFeatures
         self.assertIsInstance(self.features, PostgreSQLDatabaseFeatures)

--- a/aurora_dsql_django/tests/unit/test_wrapper.py
+++ b/aurora_dsql_django/tests/unit/test_wrapper.py
@@ -3,7 +3,8 @@ from unittest.mock import MagicMock, patch
 import django
 from django.conf import settings
 from django.db import models
-from django.db.models import CheckConstraint, Q
+from django.db.models import CheckConstraint, Q, Index, F
+from django.db.models.functions import Upper
 from aurora_dsql_django.base import DatabaseWrapper
 from aurora_dsql_django.features import DatabaseFeatures
 from aurora_dsql_django.schema import DatabaseSchemaEditor
@@ -47,7 +48,8 @@ class TestWrapper(unittest.TestCase):
         quote_patch = patch.object(self.schema_editor, 'quote_value', side_effect=simple_quote_value)
 
         with execute_patch, quote_patch:
-            operation_func()
+            with self.schema_editor:
+                operation_func()
 
         all_sql = [str(sql) for sql, _ in executed_sql]
         if hasattr(self.schema_editor, 'deferred_sql'):
@@ -70,8 +72,7 @@ class TestWrapper(unittest.TestCase):
                 app_label = 'test_app'
 
         def operation():
-            with self.schema_editor:
-                self.schema_editor.create_model(ChildModel)
+            self.schema_editor.create_model(ChildModel)
 
         self._assert_sql_not_generated(
             operation,
@@ -92,8 +93,7 @@ class TestWrapper(unittest.TestCase):
                 ]
 
         def operation():
-            with self.schema_editor:
-                self.schema_editor.create_model(CheckConstraintModel)
+            self.schema_editor.create_model(CheckConstraintModel)
 
         self._assert_sql_not_generated(
             operation,
@@ -139,6 +139,47 @@ class TestWrapper(unittest.TestCase):
             operation,
             ['CONSTRAINT'],
             "Should not execute check constraint removal SQL"
+        )
+
+
+    def test_add_index_expression_ignored(self):
+        """Ensure add_index operations ignore expression indexes when the feature is disabled"""
+
+        class AddIndexModel(models.Model):
+            name = models.CharField(max_length=100)
+
+            class Meta:
+                app_label = 'test_app'
+
+        expression_index = Index(Upper('name'), name='upper_name_idx')
+
+        def operation():
+            self.schema_editor.add_index(AddIndexModel, expression_index)
+
+        self._assert_sql_not_generated(
+            operation,
+            ['CREATE INDEX'],
+            "Should not generate index creation SQL for expression indexes"
+        )
+
+    def test_remove_index_expression_ignored(self):
+        """Ensure remove_index operations ignore expression indexes when the feature is disabled"""
+
+        class RemoveIndexModel(models.Model):
+            name = models.CharField(max_length=100)
+
+            class Meta:
+                app_label = 'test_app'
+
+        expression_index = Index(Upper('name'), name='upper_name_idx')
+
+        def operation():
+            self.schema_editor.remove_index(RemoveIndexModel, expression_index)
+
+        self._assert_sql_not_generated(
+            operation,
+            ['DROP INDEX'],
+            "Should not generate index removal SQL for expression indexes"
         )
 
 

--- a/aurora_dsql_django/tests/unit/test_wrapper.py
+++ b/aurora_dsql_django/tests/unit/test_wrapper.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import django
 from django.conf import settings
 from django.db import models
-from django.db.models import CheckConstraint, Q, Index, F
+from django.db.models import CheckConstraint, Q, Index
 from django.db.models.functions import Upper
 from aurora_dsql_django.base import DatabaseWrapper
 from aurora_dsql_django.features import DatabaseFeatures


### PR DESCRIPTION
This PR fixes up the definitions around expression indexes, which are not supported by DSQL.

It defines the `supports_expression_indexes` feature flag to indicate this, and adds tests to cover the wrapper-level behavior of the `add_index` and `remove_index` overrides in the `schema.py` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
