### PR TITLE
Remove no-op overrides for ALTER TABLE operations

### DIFF
--- a/aurora_dsql_django/schema.py
+++ b/aurora_dsql_django/schema.py
@@ -48,11 +48,6 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
         "UPDATE %(table)s SET %(column)s = %(default)s WHERE %(column)s IS NULL"
     )
 
-    # These "ALTER TABLE" operations are not supported.
-    sql_create_pk = ""
-    sql_delete_constraint = ""
-    sql_delete_column = ""
-
     def __enter__(self):
         super().__enter__()
         # As long as DatabaseFeatures.can_rollback_ddl = False, compose() may

--- a/aurora_dsql_django/tests/unit/test_schema.py
+++ b/aurora_dsql_django/tests/unit/test_schema.py
@@ -16,7 +16,6 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
         self.schema_editor = DatabaseSchemaEditor(self.connection)
 
     def test_sql_attributes(self):
-        self.assertEqual(self.schema_editor.sql_create_pk, "")
         self.assertEqual(self.schema_editor.sql_create_index,
                          "CREATE INDEX ASYNC %(name)s ON %(table)s%(using)s (%(columns)s)%(include)s%(extra)s%(condition)s")
         self.assertEqual(self.schema_editor.sql_create_unique,
@@ -28,8 +27,6 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
             self.schema_editor.sql_update_with_default,
             "UPDATE %(table)s SET %(column)s = %(default)s WHERE %(column)s IS NULL"
         )
-        self.assertEqual(self.schema_editor.sql_delete_constraint, "")
-        self.assertEqual(self.schema_editor.sql_delete_column, "")
 
     @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_index')
     def test_add_index_with_expressions(self, mock_super_add_index):


### PR DESCRIPTION
This PR removes the current configuration for the following operations:

- `sql_create_pk`
- `sql_delete_constraint`
- `sql_delete_column`

Each of these operations uses an `ALTER TABLE` statement which is not supported by DSQL. The previous approach was to replace the statement with an empty query, but this allows the migration to continue despite the operation having not been performed.

By removing the override, we fall back to the statement defined by the base class which uses `ALTER TABLE`. This will result in the statement being sent to DSQL, which will return an error. While this seemingly causes migrations to fail where they previously didn't, the failure is more correct in this scenario. By skipping the statement, we would be leaving the database in a state which differs from what the migration expects.

For customer migrations, these operations should be avoided. For Django apps, manual steps may be needed to work around migrations that use these operations.

It doesn't make a lot of sense to add a test for this, since we are now falling back to the functionality already defined and tested in the base class for the `schema.py` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
