### PR TITLE
Fix foreign key references to UUID primary key type

### DIFF
--- a/aurora_dsql_django/base.py
+++ b/aurora_dsql_django/base.py
@@ -22,7 +22,9 @@ import logging
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
 
+from django.db import models
 from django.db.backends.postgresql import base
+from django.db.models.fields import Field
 
 from .creation import DatabaseCreation
 from .features import DatabaseFeatures
@@ -104,6 +106,28 @@ class DatabaseWrapper(base.DatabaseWrapper):
         SmallAutoField="",
         AutoField="DEFAULT gen_random_uuid()",
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._patch_autofields()
+
+    def _patch_autofields(self):
+        """
+        Patch AutoField classes to return UUID type for related fields.
+        This ensures ForeignKey fields that reference AutoFields are also UUIDs.
+        """
+
+        def uuid_rel_db_type(self, connection):
+            return "uuid"
+
+        def uuid_get_prep_value(self, value):
+            """Override get_prep_value to prevent int() conversion of UUIDs."""
+            return Field.get_prep_value(self, value)
+
+        models.AutoField.rel_db_type = uuid_rel_db_type
+        models.AutoField.get_prep_value = uuid_get_prep_value
+        models.BigAutoField.rel_db_type = uuid_rel_db_type
+        models.BigAutoField.get_prep_value = uuid_get_prep_value
 
     SchemaEditorClass = DatabaseSchemaEditor
     creation_class = DatabaseCreation

--- a/aurora_dsql_django/base.py
+++ b/aurora_dsql_django/base.py
@@ -27,6 +27,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.backends.postgresql import base
 from django.db.models.fields import Field
+from django.utils.translation import gettext_lazy
 
 from .creation import DatabaseCreation
 from .features import DatabaseFeatures
@@ -142,12 +143,13 @@ class DatabaseWrapper(base.DatabaseWrapper):
                 params={"value": value},
             )
 
-        models.AutoField.rel_db_type = uuid_rel_db_type
-        models.AutoField.get_prep_value = uuid_get_prep_value
-        models.AutoField.to_python = uuid_to_python
-        models.BigAutoField.rel_db_type = uuid_rel_db_type
-        models.BigAutoField.get_prep_value = uuid_get_prep_value
-        models.BigAutoField.to_python = uuid_to_python
+        for field_class in [models.AutoField, models.BigAutoField]:
+            field_class.rel_db_type = uuid_rel_db_type
+            field_class.get_prep_value = uuid_get_prep_value
+            field_class.to_python = uuid_to_python
+            field_class.default_error_messages = {
+                "invalid": gettext_lazy("'%(value)s' value must be a valid UUID."),
+            }
 
     SchemaEditorClass = DatabaseSchemaEditor
     creation_class = DatabaseCreation

--- a/aurora_dsql_django/base.py
+++ b/aurora_dsql_django/base.py
@@ -23,6 +23,7 @@ import uuid
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.backends.postgresql import base
 from django.db.models.fields import Field
@@ -126,16 +127,20 @@ class DatabaseWrapper(base.DatabaseWrapper):
             return Field.get_prep_value(self, value)
 
         def uuid_to_python(self, value):
-            """Convert UUID strings to UUID objects, handle both UUIDs and integers gracefully."""
-            if value is None:
+            """Convert provided value to a UUID where possible."""
+            if value is None or isinstance(value, uuid.UUID):
                 return value
             if isinstance(value, str):
                 try:
                     return uuid.UUID(value)
                 except ValueError:
-                    # If it's not a valid UUID, treat it as the original field would.
-                    return Field.to_python(self, value)
-            return value
+                    pass
+
+            raise ValidationError(
+                self.error_messages["invalid"],
+                code="invalid",
+                params={"value": value},
+            )
 
         models.AutoField.rel_db_type = uuid_rel_db_type
         models.AutoField.get_prep_value = uuid_get_prep_value

--- a/aurora_dsql_django/base.py
+++ b/aurora_dsql_django/base.py
@@ -19,9 +19,10 @@ N seconds. This module extends the base wrapper to handle this case.
 """
 
 import logging
+import uuid
+
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError
-
 from django.db import models
 from django.db.backends.postgresql import base
 from django.db.models.fields import Field
@@ -124,10 +125,24 @@ class DatabaseWrapper(base.DatabaseWrapper):
             """Override get_prep_value to prevent int() conversion of UUIDs."""
             return Field.get_prep_value(self, value)
 
+        def uuid_to_python(self, value):
+            """Convert UUID strings to UUID objects, handle both UUIDs and integers gracefully."""
+            if value is None:
+                return value
+            if isinstance(value, str):
+                try:
+                    return uuid.UUID(value)
+                except ValueError:
+                    # If it's not a valid UUID, treat it as the original field would.
+                    return Field.to_python(self, value)
+            return value
+
         models.AutoField.rel_db_type = uuid_rel_db_type
         models.AutoField.get_prep_value = uuid_get_prep_value
+        models.AutoField.to_python = uuid_to_python
         models.BigAutoField.rel_db_type = uuid_rel_db_type
         models.BigAutoField.get_prep_value = uuid_get_prep_value
+        models.BigAutoField.to_python = uuid_to_python
 
     SchemaEditorClass = DatabaseSchemaEditor
     creation_class = DatabaseCreation

--- a/aurora_dsql_django/operations.py
+++ b/aurora_dsql_django/operations.py
@@ -31,3 +31,12 @@ class DatabaseOperations(operations.DatabaseOperations):
     def deferrable_sql(self):
         # Deferrable constraints aren't supported:
         return ""
+
+    def integer_field_range(self, internal_type):
+        """
+        Override to handle UUIDField which doesn't have integer ranges.
+        """
+        if internal_type == "UUIDField":
+            # Skip validation.
+            return None, None
+        return super().integer_field_range(internal_type)

--- a/aurora_dsql_django/tests/unit/test_base.py
+++ b/aurora_dsql_django/tests/unit/test_base.py
@@ -3,6 +3,7 @@ import uuid
 from unittest.mock import patch, MagicMock
 
 from botocore.exceptions import BotoCoreError
+from django.core.exceptions import ValidationError
 from django.db import models
 
 from aurora_dsql_django.base import get_aws_connection_params, DatabaseWrapper
@@ -239,19 +240,25 @@ class TestAuroraDSQLBackend(unittest.TestCase):
         self.assertIsNone(result_auto)
         self.assertIsNone(result_big)
 
-    def test_autofield_to_python_invalid_uuid_fallback(self):
-        """Test that AutoField.to_python falls back gracefully for invalid UUIDs."""
+    def test_autofield_to_python_invalid_uuid_error(self):
+        """Test that AutoField.to_python raises ValidationError for invalid UUIDs."""
         autofield = models.AutoField()
         bigautofield = models.BigAutoField()
-        
+
         invalid_uuid_string = "not-a-uuid"
-        
-        result_auto = autofield.to_python(invalid_uuid_string)
-        result_big = bigautofield.to_python(invalid_uuid_string)
-        
-        # Should return the original value when UUID conversion fails.
-        self.assertEqual(result_auto, invalid_uuid_string)
-        self.assertEqual(result_big, invalid_uuid_string)
+
+        with self.assertRaises(ValidationError):
+            autofield.to_python(invalid_uuid_string)
+
+        with self.assertRaises(ValidationError):
+            bigautofield.to_python(invalid_uuid_string)
+
+    def test_autofield_to_python_non_uuid_type_error(self):
+        """Test that AutoField.to_python raises ValidationError for non-uuid-compatible types."""
+        autofield = models.AutoField()
+
+        with self.assertRaises(ValidationError):
+            autofield.to_python(123)
 
 
 if __name__ == '__main__':

--- a/aurora_dsql_django/tests/unit/test_base.py
+++ b/aurora_dsql_django/tests/unit/test_base.py
@@ -1,7 +1,12 @@
 import unittest
+import uuid
 from unittest.mock import patch, MagicMock
-from aurora_dsql_django.base import get_aws_connection_params, DatabaseWrapper
+
 from botocore.exceptions import BotoCoreError
+from django.db import models
+
+from aurora_dsql_django.base import get_aws_connection_params, DatabaseWrapper
+from aurora_dsql_django.operations import DatabaseOperations
 
 
 class TestAuroraDSQLBackend(unittest.TestCase):
@@ -13,6 +18,9 @@ class TestAuroraDSQLBackend(unittest.TestCase):
             "user": "test-user",
             "name": "test-db"
         }
+
+        self.wrapper = DatabaseWrapper({})
+        self.ops = DatabaseOperations(connection=MagicMock())
 
     @patch('aurora_dsql_django.base.boto3.session.Session')
     def test_get_aws_connection_params_without_profile(self, mock_session):
@@ -105,19 +113,17 @@ class TestAuroraDSQLBackend(unittest.TestCase):
             get_aws_connection_params(self.base_params.copy())
 
     def test_database_wrapper_data_types(self):
-        wrapper = DatabaseWrapper({})
-        self.assertEqual(wrapper.data_types['BigAutoField'], "uuid")
-        self.assertEqual(wrapper.data_types['AutoField'], "uuid")
-        self.assertEqual(wrapper.data_types['DateTimeField'], "timestamptz")
+        self.assertEqual(self.wrapper.data_types['BigAutoField'], "uuid")
+        self.assertEqual(self.wrapper.data_types['AutoField'], "uuid")
+        self.assertEqual(self.wrapper.data_types['DateTimeField'], "timestamptz")
 
     def test_database_wrapper_data_types_suffix(self):
-        wrapper = DatabaseWrapper({})
         self.assertEqual(
-            wrapper.data_types_suffix['BigAutoField'],
+            self.wrapper.data_types_suffix['BigAutoField'],
             "DEFAULT gen_random_uuid()")
-        self.assertEqual(wrapper.data_types_suffix['SmallAutoField'], "")
+        self.assertEqual(self.wrapper.data_types_suffix['SmallAutoField'], "")
         self.assertEqual(
-            wrapper.data_types_suffix['AutoField'],
+            self.wrapper.data_types_suffix['AutoField'],
             "DEFAULT gen_random_uuid()")
 
     @patch('aurora_dsql_django.base.get_aws_connection_params')
@@ -164,6 +170,34 @@ class TestAuroraDSQLBackend(unittest.TestCase):
         with wrapper.constraint_checks_disabled():
             # This context manager should not raise any exception
             pass
+
+    def test_autofield_rel_db_type_returns_uuid(self):
+        """Test that AutoField rel_db_type returns uuid for foreign keys."""
+        autofield = models.AutoField()
+        bigautofield = models.BigAutoField()
+
+        self.assertEqual(autofield.rel_db_type(self.wrapper), 'uuid')
+        self.assertEqual(bigautofield.rel_db_type(self.wrapper), 'uuid')
+
+    def test_autofield_get_prep_value_preserves_uuid(self):
+        """Test that AutoField get_prep_value doesn't convert UUIDs to int."""
+        autofield = models.AutoField()
+        bigautofield = models.BigAutoField()
+
+        test_uuid = uuid.uuid4()
+
+        # Should preserve UUID values.
+        self.assertEqual(autofield.get_prep_value(test_uuid), test_uuid)
+        self.assertEqual(bigautofield.get_prep_value(test_uuid), test_uuid)
+
+        # Should preserve None, which tells Django to use database default.
+        self.assertIsNone(autofield.get_prep_value(None))
+        self.assertIsNone(bigautofield.get_prep_value(None))
+
+    def test_operations_cast_data_types(self):
+        """Test that operations class maps AutoFields to uuid for casting."""
+        self.assertEqual(self.ops.cast_data_types['AutoField'], 'uuid')
+        self.assertEqual(self.ops.cast_data_types['BigAutoField'], 'uuid')
 
 
 if __name__ == '__main__':

--- a/aurora_dsql_django/tests/unit/test_base.py
+++ b/aurora_dsql_django/tests/unit/test_base.py
@@ -2,12 +2,21 @@ import unittest
 import uuid
 from unittest.mock import patch, MagicMock
 
+import django
+from django.conf import settings
 from botocore.exceptions import BotoCoreError
 from django.core.exceptions import ValidationError
 from django.db import models
 
 from aurora_dsql_django.base import get_aws_connection_params, DatabaseWrapper
 from aurora_dsql_django.operations import DatabaseOperations
+
+if not settings.configured:
+    settings.configure(
+        USE_I18N=True,
+        DATABASES={'default': {'ENGINE': 'aurora_dsql_django'}},
+    )
+    django.setup()
 
 
 class TestAuroraDSQLBackend(unittest.TestCase):
@@ -259,6 +268,17 @@ class TestAuroraDSQLBackend(unittest.TestCase):
 
         with self.assertRaises(ValidationError):
             autofield.to_python(123)
+
+    def test_autofield_error_message_content(self):
+        """Test that AutoField validation errors contain correct UUID message."""
+        autofield = models.AutoField()
+        
+        with self.assertRaises(ValidationError) as cm:
+            autofield.to_python(123)
+        
+        error_message = str(cm.exception.messages[0])
+        self.assertIn("must be a valid UUID", error_message)
+        self.assertIn("123", error_message)
 
 
 if __name__ == '__main__':

--- a/aurora_dsql_django/tests/unit/test_base.py
+++ b/aurora_dsql_django/tests/unit/test_base.py
@@ -199,6 +199,60 @@ class TestAuroraDSQLBackend(unittest.TestCase):
         self.assertEqual(self.ops.cast_data_types['AutoField'], 'uuid')
         self.assertEqual(self.ops.cast_data_types['BigAutoField'], 'uuid')
 
+    def test_autofield_to_python_uuid_conversion(self):
+        """Test that AutoField.to_python converts UUID strings to UUID objects."""
+        autofield = models.AutoField()
+        bigautofield = models.BigAutoField()
+
+        # Test with valid UUID string.
+        uuid_string = "8fcc0dd2-1d96-4428-a619-f0e43996dc19"
+        
+        result_auto = autofield.to_python(uuid_string)
+        result_big = bigautofield.to_python(uuid_string)
+        
+        # Should convert to UUID objects.
+        self.assertIsInstance(result_auto, uuid.UUID)
+        self.assertIsInstance(result_big, uuid.UUID)
+        self.assertEqual(str(result_auto), uuid_string)
+        self.assertEqual(str(result_big), uuid_string)
+
+    def test_autofield_to_python_with_uuid_object(self):
+        """Test that AutoField.to_python handles existing UUID objects."""
+        autofield = models.AutoField()
+        bigautofield = models.BigAutoField()
+        
+        uuid_obj = uuid.UUID("8fcc0dd2-1d96-4428-a619-f0e43996dc19")
+        result_auto = autofield.to_python(uuid_obj)
+        result_big = bigautofield.to_python(uuid_obj)
+        
+        self.assertEqual(result_auto, uuid_obj)
+        self.assertEqual(result_big, uuid_obj)
+
+    def test_autofield_to_python_with_none(self):
+        """Test that AutoField.to_python handles None values."""
+        autofield = models.AutoField()
+        bigautofield = models.BigAutoField()
+        
+        result_auto = autofield.to_python(None)
+        result_big = bigautofield.to_python(None)
+        
+        self.assertIsNone(result_auto)
+        self.assertIsNone(result_big)
+
+    def test_autofield_to_python_invalid_uuid_fallback(self):
+        """Test that AutoField.to_python falls back gracefully for invalid UUIDs."""
+        autofield = models.AutoField()
+        bigautofield = models.BigAutoField()
+        
+        invalid_uuid_string = "not-a-uuid"
+        
+        result_auto = autofield.to_python(invalid_uuid_string)
+        result_big = bigautofield.to_python(invalid_uuid_string)
+        
+        # Should return the original value when UUID conversion fails.
+        self.assertEqual(result_auto, invalid_uuid_string)
+        self.assertEqual(result_big, invalid_uuid_string)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR updates the configuration for `AutoField` and `BigAutoField` to properly use the UUID type even when primary keys are reference through foreign keys.

During testing, I found that running default app migrations would cause an error like this:

```
django.db.utils.ProgrammingError: operator does not exist: integer = uuid
LINE 1: ...ent_type" ON ("auth_permission"."content_type_id" = CAST("dj..
```

After investigation, I found this was because the column was defined as a foreign key, where the actual column being referenced was one of the `AutoField` columns using a UUID. Since DSQL doesn't support foreign keys, the type was dealt with internally in Django, which misunderstood the type of the referenced column given it assumes `AutoField`s are integers.

To correct this, I patched the `AutoField` and `BigAutoField` class in a few places to return types which indicate they are using UUIDs. This seems to fix the foreign key reference issue and prevent this error. I checked the tables after running migrations and they both seem to have the correct UUID type now.

I don't love that we need to directly patch the `AutoField` and `BigAutoField` classes, but I couldn't find a way around it. I tried to do the patching in the driver initializer so it is not susceptible to module import variation, and should always apply correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
