### PR TITLE
Disable server-side cursors by default

### DIFF
--- a/aurora_dsql_django/base.py
+++ b/aurora_dsql_django/base.py
@@ -114,6 +114,10 @@ class DatabaseWrapper(base.DatabaseWrapper):
         super().__init__(*args, **kwargs)
         self._patch_autofields()
 
+        # Automatically disable server-side cursors since Aurora DSQL doesn't support them.
+        # We preserve the user config if it is defined but this is likely a user mistake.
+        self.settings_dict.setdefault('DISABLE_SERVER_SIDE_CURSORS', True)
+
     def _patch_autofields(self):
         """
         Patch AutoField classes to return UUID type for related fields.


### PR DESCRIPTION
This PR configures a default value for `DISABLE_SERVER_SIDE_CURSORS`, since server-side cursors are not supported by DSQL.

The default value here helps us avoid requiring customers to configure this in their own project. It also makes it easier for us to enable again if support is changed in the future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
