### PR TITLE
Add documented support for Python 3.13

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,7 +24,7 @@ jobs:
       max-parallel: 1
       matrix:
         # Run test for every python version we intend to support.
-        version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,7 +24,7 @@ jobs:
       max-parallel: 1
       matrix:
         # Run test for every python version we intend to support.
-        version: ['3.8', '3.9', '3.10', '3.11', '3.12' ]
+        version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
     permissions:
       id-token: write
       contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This PR adds documented support for Python versions `3.13` and `3.14`.

`3.14` seems to be in prerelease so this might be getting ahead of things a little bit, but if the workflows pass then this seems fine since when it is released we won't need to make another change.

See [this comment](https://github.com/awslabs/aurora-dsql-django/pull/52#discussion_r2379845044) for original ask.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
