### PR TITLE
Add repo link to published metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 
+[project.urls]
+Repository = "https://github.com/awslabs/aurora-dsql-django"
+
 [project.optional-dependencies]
 test = [
     "pytest>=8",


### PR DESCRIPTION
This PR adds additional metadata so that PyPI can link back to this repository. This will only take effect when this change is included in a future release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
