### PR TITLE
Switch to setuptools-scm for dynamic versioning

### DIFF
--- a/aurora_dsql_django/__init__.py
+++ b/aurora_dsql_django/__init__.py
@@ -12,4 +12,9 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-__version__ = '0.1.0'
+from importlib.metadata import version, PackageNotFoundError
+
+try:
+    __version__ = version("aurora_dsql_django")
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,15 +36,15 @@ dev = [
     "docutils>=0.18.0,<0.21.0",
     "pip>=24.3.1,<25.0.0",
     "guzzle_sphinx_theme~=0.7.11",
-    "setuptools>=61.0"
+    "setuptools>=61.0",
+    "setuptools-scm>=8"
 ]
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools.dynamic]
-version = {attr = "aurora_dsql_django.__version__"}
+[tool.setuptools_scm]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/uv.lock
+++ b/uv.lock
@@ -86,6 +86,7 @@ dev = [
     { name = "pip" },
     { name = "setuptools", version = "75.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "setuptools", version = "80.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "setuptools-scm" },
     { name = "sphinx", version = "7.1.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "sphinx", version = "7.4.7", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
 ]
@@ -115,10 +116,11 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = ">=61.0" },
+    { name = "setuptools-scm", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=7.1.0,<8.0.0" },
     { name = "wheel", marker = "extra == 'test'" },
 ]
-provides-extras = ["test", "dev"]
+provides-extras = ["dev", "test"]
 
 [[package]]
 name = "babel"
@@ -1286,6 +1288,23 @@ resolution-markers = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
+]
+
+[[package]]
+name = "setuptools-scm"
+version = "9.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools", version = "75.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "setuptools", version = "80.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", version = "4.13.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "typing-extensions", version = "4.15.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.9.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/8d/ffdcace33d0480d591057a30285b7c33f8dc431fed3fff7dbadf5f9f128f/setuptools_scm-9.2.0.tar.gz", hash = "sha256:6662c9b9497b6c9bf13bead9d7a9084756f68238302c5ed089fb4dbd29d102d7", size = 201229, upload-time = "2025-08-16T12:56:39.477Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/14/dd3a6053325e882fe191fb4b42289bbdfabf5f44307c302903a8a3236a0a/setuptools_scm-9.2.0-py3-none-any.whl", hash = "sha256:c551ef54e2270727ee17067881c9687ca2aedf179fa5b8f3fab9e8d73bdc421f", size = 62099, upload-time = "2025-08-16T12:56:37.912Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR uses [setuptools-scm](https://setuptools-scm.readthedocs.io/en/latest/) to avoid explicit version references in the source code.

This will make maintenance easier, as we don't need to worry about the version in the source code becoming out of sync with GitHub releases.

In my testing, `uv build` uses the expected version number when a tag is present, and uses a dev-specific version when no such tag is present. We may additionally find this useful at some point if a customer reports an issues showing a development version, as it means they are building from modified source code which may be relevant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
