### PR TITLE
Allow release workflow to be temporarily invoked manually

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to simulate'
+        required: true
+        default: 'v0.0.0'
 
 permissions:
   contents: write
@@ -26,7 +32,7 @@ jobs:
 
       - name: Commit and push changelog
         run: |
-          TAG_NAME="${{ github.event.release.tag_name }}"
+          TAG_NAME="${{ github.event.release.tag_name || github.event.inputs.tag_name }}"
           BRANCH_NAME="changelog-update-$TAG_NAME"
           git checkout -b $BRANCH_NAME
           git config --local user.email "action@github.com"


### PR DESCRIPTION
I recently merged #59 but it turns out I need to configure the manual invocation event on the default branch too, it doesn't show up on my dev branch.

Given this "release" workflow doesn't actually release anything right now, allowing this to be invoked manually isn't a huge deal. I will revert this change after testing the changelog behavior.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
