### PR TITLE
Use built-in changelog PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,6 @@ name: Release
 on:
   release:
     types: [ published ]
-  workflow_dispatch:
-    inputs:
-      tag_name:
-        description: 'Tag name to simulate'
-        required: true
-        default: 'v0.0.0'
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: [published]
+    types: [ published ]
   workflow_dispatch:
     inputs:
       tag_name:
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 env:
   DEFAULT_BRANCH: version-0
@@ -20,33 +21,22 @@ jobs:
   update-changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout tag for build & publish
+        uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      # TODO: Add build/publish steps here that use the tagged version
+
+      - name: Checkout default branch for changelog
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ env.DEFAULT_BRANCH }}
 
       - name: Update changelog
         uses: rhysd/changelog-from-release/action@v3
         with:
           file: CHANGELOG.md
           github_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Commit and push changelog
-        run: |
-          TAG_NAME="${{ github.event.release.tag_name || github.event.inputs.tag_name }}"
-          BRANCH_NAME="changelog-update-$TAG_NAME"
-          git checkout -b $BRANCH_NAME
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add CHANGELOG.md
-          if ! git diff --staged --quiet; then
-            git commit -m "Update CHANGELOG.md for $TAG_NAME"
-            git push origin $BRANCH_NAME
-
-            gh pr create \
-              --title "Update CHANGELOG.md for $TAG_NAME" \
-              --body "Automated changelog update for release $TAG_NAME" \
-              --base ${{ env.DEFAULT_BRANCH }} \
-              --head $BRANCH_NAME
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          pull_request: true


### PR DESCRIPTION
It turns out the `changelog-from-release` action supports creating the PR directly, so we don't need the manual PR creation steps. I found this because during testing it tried to push directly to the default branch which was denied by our branch protection rules.

I've added a secondary checkout action since we will want to build and publish the actual released tag, but then push `CHANGELOG.md` changes to the default branch. This is a little confusing in the current state of this workflow file since there are no build/publish steps, so I've added a placeholder `TODO` to make it a bit clearer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
