### PR TITLE
Format files with ruff

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -60,6 +60,13 @@ jobs:
         uv run python3 -c "import boto3; print(boto3.__version__)"
         echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
 
+    - name: Lint with ruff
+      run: |
+        # Check code formatting
+        uv run ruff format --check .
+        # Run linting
+        uv run ruff check .
+
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/aurora_dsql_django/__init__.py
+++ b/aurora_dsql_django/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions
 # and limitations under the License.
 
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("aurora_dsql_django")

--- a/aurora_dsql_django/base.py
+++ b/aurora_dsql_django/base.py
@@ -54,31 +54,26 @@ def get_aws_connection_params(params):
     user = params.get("user")
     sslmode = params.get("sslmode", None)
     sslrootcert = params.get("sslrootcert", None)
-    if sslrootcert is None and sslmode == 'verify-full':
+    if sslrootcert is None and sslmode == "verify-full":
         params["sslrootcert"] = "system"
     expires_in = params.pop("expires_in", None)
     aws_profile = params.pop("aws_profile", None)
 
     try:
-        session = boto3.session.Session(
-            profile_name=aws_profile) if aws_profile else boto3.session.Session()
+        session = boto3.session.Session(profile_name=aws_profile) if aws_profile else boto3.session.Session()
         client = session.client("dsql", region_name=region)
 
         # Set correct IAM Auth token
-        is_admin = user == 'admin'
+        is_admin = user == "admin"
         has_expires_in = expires_in is not None
         if is_admin and has_expires_in:
-            params["password"] = client.generate_db_connect_admin_auth_token(
-                hostname, region, expires_in)
+            params["password"] = client.generate_db_connect_admin_auth_token(hostname, region, expires_in)
         elif is_admin and not has_expires_in:
-            params["password"] = client.generate_db_connect_admin_auth_token(
-                hostname, region)
+            params["password"] = client.generate_db_connect_admin_auth_token(hostname, region)
         elif not is_admin and has_expires_in:
-            params["password"] = client.generate_db_connect_auth_token(
-                hostname, region, expires_in)
+            params["password"] = client.generate_db_connect_auth_token(hostname, region, expires_in)
         else:
-            params["password"] = client.generate_db_connect_auth_token(
-                hostname, region)
+            params["password"] = client.generate_db_connect_auth_token(hostname, region)
 
         params.setdefault("port", 5432)
 
@@ -93,6 +88,7 @@ class DatabaseWrapper(base.DatabaseWrapper):
     """
     A wrapper class that adapts the Django base API for Aurora DSQL
     """
+
     vendor = "dsql"
     display_name = "Aurora DSQL"
     # Override some types from the postgresql adapter.
@@ -116,7 +112,7 @@ class DatabaseWrapper(base.DatabaseWrapper):
 
         # Automatically disable server-side cursors since Aurora DSQL doesn't support them.
         # We preserve the user config if it is defined but this is likely a user mistake.
-        self.settings_dict.setdefault('DISABLE_SERVER_SIDE_CURSORS', True)
+        self.settings_dict.setdefault("DISABLE_SERVER_SIDE_CURSORS", True)
 
     def _patch_autofields(self):
         """

--- a/aurora_dsql_django/creation.py
+++ b/aurora_dsql_django/creation.py
@@ -22,9 +22,7 @@ from django.db.backends.postgresql import creation
 
 
 class DatabaseCreation(creation.DatabaseCreation):
-
     def _clone_test_db(self, suffix, verbosity, keepdb=False):
         raise NotImplementedError(
-            "Aurora DSQL doesn't support cloning databases. "
-            "Disable the option to run tests in parallel processes."
+            "Aurora DSQL doesn't support cloning databases. Disable the option to run tests in parallel processes."
         )

--- a/aurora_dsql_django/operations.py
+++ b/aurora_dsql_django/operations.py
@@ -21,7 +21,6 @@ from django.db.backends.postgresql import operations
 
 
 class DatabaseOperations(operations.DatabaseOperations):
-
     cast_data_types = {
         "AutoField": "uuid",
         "BigAutoField": "uuid",

--- a/aurora_dsql_django/schema.py
+++ b/aurora_dsql_django/schema.py
@@ -25,17 +25,14 @@ from django.db.models import CheckConstraint
 class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     """
     Aurora DSQL schema editor based on the PostgreSQL backend.
-    
+
     Aurora DSQL is PostgreSQL-compatible but supports a subset of PostgreSQL
     operations. This class overrides SQL templates and methods to work within
     DSQL's constraints.
     """
 
     # Use DSQL's async index creation syntax.
-    sql_create_index = (
-        "CREATE INDEX ASYNC %(name)s ON %(table)s%(using)s "
-        "(%(columns)s)%(include)s%(extra)s%(condition)s"
-    )
+    sql_create_index = "CREATE INDEX ASYNC %(name)s ON %(table)s%(using)s (%(columns)s)%(include)s%(extra)s%(condition)s"
 
     # Create unique constraints as unique indexes instead of using "ALTER TABLE".
     sql_create_unique = "CREATE UNIQUE INDEX ASYNC %(name)s ON %(table)s (%(columns)s)"
@@ -44,9 +41,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
     sql_delete_unique = "DROP INDEX %(name)s CASCADE"
 
     # Remove constraint management from default updates.
-    sql_update_with_default = (
-        "UPDATE %(table)s SET %(column)s = %(default)s WHERE %(column)s IS NULL"
-    )
+    sql_update_with_default = "UPDATE %(table)s SET %(column)s = %(default)s WHERE %(column)s IS NULL"
 
     def __enter__(self):
         super().__enter__()
@@ -89,9 +84,7 @@ class DatabaseSchemaEditor(schema.DatabaseSchemaEditor):
 
     def _index_columns(self, table, columns, col_suffixes, opclasses):
         # Aurora DSQL doesn't support PostgreSQL opclasses.
-        return BaseDatabaseSchemaEditor._index_columns(
-            self, table, columns, col_suffixes, opclasses
-        )
+        return BaseDatabaseSchemaEditor._index_columns(self, table, columns, col_suffixes, opclasses)
 
     def _create_like_index_sql(self, model, field):
         # Aurora DSQL doesn't support LIKE indexes which use postgres

--- a/aurora_dsql_django/tests/integration/test_dsql.py
+++ b/aurora_dsql_django/tests/integration/test_dsql.py
@@ -1,14 +1,15 @@
 import os
-from django.test import TestCase
+
 from django.db import connections, transaction
+from django.test import TestCase
 
 
 class TestAuroraDSQLAdapter(TestCase):
-    databases = {'default'}
+    databases = {"default"}
 
     @classmethod
     def setUpClass(cls):
-        cls.connection = connections['default']
+        cls.connection = connections["default"]
         transaction.set_autocommit(False)
         super().setUpClass()
 
@@ -21,10 +22,9 @@ class TestAuroraDSQLAdapter(TestCase):
     def test_connection_params(self):
         params = self.connection.get_connection_params()
 
-        self.assertEqual(
-            params['host'], os.environ.get('CLUSTER_ENDPOINT', None))
-        self.assertEqual(params['user'], 'admin')
-        self.assertIn('password', params)
+        self.assertEqual(params["host"], os.environ.get("CLUSTER_ENDPOINT", None))
+        self.assertEqual(params["user"], "admin")
+        self.assertIn("password", params)
 
         # Test database connection
         with self.connection.cursor() as cursor:
@@ -36,7 +36,7 @@ class TestAuroraDSQLAdapter(TestCase):
 
     def test_aws_connection_params(self):
         result = self.connection.get_connection_params()
-        self.assertIn('password', result)
+        self.assertIn("password", result)
 
     def test_table_creation(self):
         with self.connection.cursor() as cursor:
@@ -45,12 +45,10 @@ class TestAuroraDSQLAdapter(TestCase):
                 cursor.execute("BEGIN")
 
                 # Create table
-                cursor.execute(
-                    "CREATE TABLE foobar (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), name TEXT)")
+                cursor.execute("CREATE TABLE foobar (id UUID PRIMARY KEY DEFAULT gen_random_uuid(), name TEXT)")
 
                 # Verify index creation
-                cursor.execute(
-                    "SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'foobar'")
+                cursor.execute("SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'foobar'")
                 count = cursor.fetchone()[0]
                 self.assertEqual(count, 1)
 
@@ -62,10 +60,9 @@ class TestAuroraDSQLAdapter(TestCase):
 
                 # Delete the table
                 cursor.execute("DROP TABLE IF EXISTS foobar")
-                
+
                 # Verify index destruction
-                cursor.execute(
-                    "SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'foobar'")
+                cursor.execute("SELECT COUNT(*) FROM pg_indexes WHERE tablename = 'foobar'")
                 count = cursor.fetchone()[0]
                 self.assertEqual(count, 0)
 
@@ -79,7 +76,6 @@ class TestAuroraDSQLAdapter(TestCase):
 
             finally:
                 # Verify that the table has been deleted
-                cursor.execute(
-                    "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'test_index'")
+                cursor.execute("SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'test_index'")
                 count = cursor.fetchone()[0]
                 self.assertEqual(count, 0)

--- a/aurora_dsql_django/tests/test_settings.py
+++ b/aurora_dsql_django/tests/test_settings.py
@@ -1,31 +1,31 @@
 import os
 import sys
 
-cluster_endpoint = os.environ.get('CLUSTER_ENDPOINT', None)
+cluster_endpoint = os.environ.get("CLUSTER_ENDPOINT", None)
 if cluster_endpoint is None:
     sys.exit("CLUSTER_ENDPOINT environment variable is not set")
 
 # Override with our test-specific settings
 DATABASES = {
-    'default': {
-        'HOST': cluster_endpoint,
-        'USER': 'admin',
-        'NAME': 'postgres',
-        'ENGINE': 'aurora_dsql_django',
-        'PORT': '5432',
-        'OPTIONS': {
-                'sslmode': 'verify-full',
-                'region': 'us-east-1',
-                'expires_in': 5,
-        }
+    "default": {
+        "HOST": cluster_endpoint,
+        "USER": "admin",
+        "NAME": "postgres",
+        "ENGINE": "aurora_dsql_django",
+        "PORT": "5432",
+        "OPTIONS": {
+            "sslmode": "verify-full",
+            "region": "us-east-1",
+            "expires_in": 5,
+        },
     }
 }
 USE_TZ = True
 
 # Add other necessary Django settings
 INSTALLED_APPS = [
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
     # Add other apps as needed
 ]
 

--- a/aurora_dsql_django/tests/unit/test_base.py
+++ b/aurora_dsql_django/tests/unit/test_base.py
@@ -1,38 +1,32 @@
 import unittest
 import uuid
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import django
-from django.conf import settings
 from botocore.exceptions import BotoCoreError
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 
-from aurora_dsql_django.base import get_aws_connection_params, DatabaseWrapper
+from aurora_dsql_django.base import DatabaseWrapper, get_aws_connection_params
 from aurora_dsql_django.operations import DatabaseOperations
 
 if not settings.configured:
     settings.configure(
         USE_I18N=True,
-        DATABASES={'default': {'ENGINE': 'aurora_dsql_django'}},
+        DATABASES={"default": {"ENGINE": "aurora_dsql_django"}},
     )
     django.setup()
 
 
 class TestAuroraDSQLBackend(unittest.TestCase):
-
     def setUp(self):
-        self.base_params = {
-            "host": "test-host",
-            "region": "us-west-2",
-            "user": "test-user",
-            "name": "test-db"
-        }
+        self.base_params = {"host": "test-host", "region": "us-west-2", "user": "test-user", "name": "test-db"}
 
         self.wrapper = DatabaseWrapper({})
         self.ops = DatabaseOperations(connection=MagicMock())
 
-    @patch('aurora_dsql_django.base.boto3.session.Session')
+    @patch("aurora_dsql_django.base.boto3.session.Session")
     def test_get_aws_connection_params_without_profile(self, mock_session):
         mock_client = MagicMock()
         mock_session.return_value.client.return_value = mock_client
@@ -41,14 +35,12 @@ class TestAuroraDSQLBackend(unittest.TestCase):
         result = get_aws_connection_params(self.base_params.copy())
 
         mock_session.assert_called_once_with()
-        mock_session.return_value.client.assert_called_once_with(
-            "dsql", region_name="us-west-2")
-        mock_client.generate_db_connect_auth_token.assert_called_once_with(
-            "test-host", "us-west-2")
+        mock_session.return_value.client.assert_called_once_with("dsql", region_name="us-west-2")
+        mock_client.generate_db_connect_auth_token.assert_called_once_with("test-host", "us-west-2")
         self.assertEqual(result["password"], "test-token")
         self.assertNotIn("region", result)
 
-    @patch('aurora_dsql_django.base.boto3.session.Session')
+    @patch("aurora_dsql_django.base.boto3.session.Session")
     def test_get_aws_connection_params_with_admin_user(self, mock_session):
         mock_client = MagicMock()
         mock_session.return_value.client.return_value = mock_client
@@ -57,17 +49,14 @@ class TestAuroraDSQLBackend(unittest.TestCase):
         result = get_aws_connection_params(self.base_params.copy())
 
         mock_session.assert_called_once_with()
-        mock_session.return_value.client.assert_called_once_with(
-            "dsql", region_name="us-west-2")
-        mock_client.generate_db_connect_admin_auth_token.assert_called_once_with(
-            "test-host", "us-west-2")
+        mock_session.return_value.client.assert_called_once_with("dsql", region_name="us-west-2")
+        mock_client.generate_db_connect_admin_auth_token.assert_called_once_with("test-host", "us-west-2")
         self.assertEqual(result["password"], "admin-token")
         self.assertNotIn("region", result)
         self.base_params["user"] = "test-user"
 
-    @patch('aurora_dsql_django.base.boto3.session.Session')
-    def test_get_aws_connection_params_with_admin_user_and_expires_in(
-            self, mock_session):
+    @patch("aurora_dsql_django.base.boto3.session.Session")
+    def test_get_aws_connection_params_with_admin_user_and_expires_in(self, mock_session):
         mock_client = MagicMock()
         mock_session.return_value.client.return_value = mock_client
         mock_client.generate_db_connect_admin_auth_token.return_value = "admin-token-with-expires-in"
@@ -76,19 +65,16 @@ class TestAuroraDSQLBackend(unittest.TestCase):
         result = get_aws_connection_params(self.base_params.copy())
 
         mock_session.assert_called_once_with()
-        mock_session.return_value.client.assert_called_once_with(
-            "dsql", region_name="us-west-2")
-        mock_client.generate_db_connect_admin_auth_token.assert_called_once_with(
-            "test-host", "us-west-2", 10)
+        mock_session.return_value.client.assert_called_once_with("dsql", region_name="us-west-2")
+        mock_client.generate_db_connect_admin_auth_token.assert_called_once_with("test-host", "us-west-2", 10)
         self.assertEqual(result["password"], "admin-token-with-expires-in")
-        self.assertNotIn('expires_in', result)
+        self.assertNotIn("expires_in", result)
         self.assertNotIn("region", result)
         self.base_params["user"] = "test-user"
         self.base_params["expires_in"] = None
 
-    @patch('aurora_dsql_django.base.boto3.session.Session')
-    def test_get_aws_connection_params_with_non_admin_user_and_expires_in(
-            self, mock_session):
+    @patch("aurora_dsql_django.base.boto3.session.Session")
+    def test_get_aws_connection_params_with_non_admin_user_and_expires_in(self, mock_session):
         mock_client = MagicMock()
         mock_session.return_value.client.return_value = mock_client
         mock_client.generate_db_connect_auth_token.return_value = "test-token-with-expires-in"
@@ -97,16 +83,14 @@ class TestAuroraDSQLBackend(unittest.TestCase):
         result = get_aws_connection_params(self.base_params.copy())
 
         mock_session.assert_called_once_with()
-        mock_session.return_value.client.assert_called_once_with(
-            "dsql", region_name="us-west-2")
-        mock_client.generate_db_connect_auth_token.assert_called_once_with(
-            "test-host", "us-west-2", 10000)
+        mock_session.return_value.client.assert_called_once_with("dsql", region_name="us-west-2")
+        mock_client.generate_db_connect_auth_token.assert_called_once_with("test-host", "us-west-2", 10000)
         self.assertEqual(result["password"], "test-token-with-expires-in")
-        self.assertNotIn('expires_in', result)
+        self.assertNotIn("expires_in", result)
         self.assertNotIn("region", result)
         self.base_params["expires_in"] = None
 
-    @patch('aurora_dsql_django.base.boto3.session.Session')
+    @patch("aurora_dsql_django.base.boto3.session.Session")
     def test_get_aws_connection_params_with_profile(self, mock_session):
         params = self.base_params.copy()
         params["aws_profile"] = "test-profile"
@@ -115,7 +99,7 @@ class TestAuroraDSQLBackend(unittest.TestCase):
 
         mock_session.assert_called_once_with(profile_name="test-profile")
 
-    @patch('aurora_dsql_django.base.boto3.session.Session')
+    @patch("aurora_dsql_django.base.boto3.session.Session")
     def test_get_aws_connection_params_error_handling(self, mock_session):
         mock_session.return_value.client.side_effect = BotoCoreError()
 
@@ -123,26 +107,21 @@ class TestAuroraDSQLBackend(unittest.TestCase):
             get_aws_connection_params(self.base_params.copy())
 
     def test_database_wrapper_data_types(self):
-        self.assertEqual(self.wrapper.data_types['BigAutoField'], "uuid")
-        self.assertEqual(self.wrapper.data_types['AutoField'], "uuid")
-        self.assertEqual(self.wrapper.data_types['DateTimeField'], "timestamptz")
+        self.assertEqual(self.wrapper.data_types["BigAutoField"], "uuid")
+        self.assertEqual(self.wrapper.data_types["AutoField"], "uuid")
+        self.assertEqual(self.wrapper.data_types["DateTimeField"], "timestamptz")
 
     def test_database_wrapper_data_types_suffix(self):
-        self.assertEqual(
-            self.wrapper.data_types_suffix['BigAutoField'],
-            "DEFAULT gen_random_uuid()")
-        self.assertEqual(self.wrapper.data_types_suffix['SmallAutoField'], "")
-        self.assertEqual(
-            self.wrapper.data_types_suffix['AutoField'],
-            "DEFAULT gen_random_uuid()")
+        self.assertEqual(self.wrapper.data_types_suffix["BigAutoField"], "DEFAULT gen_random_uuid()")
+        self.assertEqual(self.wrapper.data_types_suffix["SmallAutoField"], "")
+        self.assertEqual(self.wrapper.data_types_suffix["AutoField"], "DEFAULT gen_random_uuid()")
 
-    @patch('aurora_dsql_django.base.get_aws_connection_params')
+    @patch("aurora_dsql_django.base.get_aws_connection_params")
     def test_database_wrapper_get_connection_params(self, mock_get_aws_params):
-        mock_get_aws_params.return_value = {
-            "password": "test-token", "port": 5432}
+        mock_get_aws_params.return_value = {"password": "test-token", "port": 5432}
 
         # Mock the super().get_connection_params() call
-        with patch('django.db.backends.postgresql.base.DatabaseWrapper.get_connection_params') as mock_super:
+        with patch("django.db.backends.postgresql.base.DatabaseWrapper.get_connection_params") as mock_super:
             mock_super.return_value = {"user": "test-user", "name": "test-db"}
 
             wrapper = DatabaseWrapper({})
@@ -163,7 +142,7 @@ class TestAuroraDSQLBackend(unittest.TestCase):
         wrapper = DatabaseWrapper({})
         # This should not raise any exception
         wrapper.check_constraints()
-        wrapper.check_constraints(table_names=['table1', 'table2'])
+        wrapper.check_constraints(table_names=["table1", "table2"])
 
     def test_disable_constraint_checking(self):
         wrapper = DatabaseWrapper({})
@@ -186,8 +165,8 @@ class TestAuroraDSQLBackend(unittest.TestCase):
         autofield = models.AutoField()
         bigautofield = models.BigAutoField()
 
-        self.assertEqual(autofield.rel_db_type(self.wrapper), 'uuid')
-        self.assertEqual(bigautofield.rel_db_type(self.wrapper), 'uuid')
+        self.assertEqual(autofield.rel_db_type(self.wrapper), "uuid")
+        self.assertEqual(bigautofield.rel_db_type(self.wrapper), "uuid")
 
     def test_autofield_get_prep_value_preserves_uuid(self):
         """Test that AutoField get_prep_value doesn't convert UUIDs to int."""
@@ -206,8 +185,8 @@ class TestAuroraDSQLBackend(unittest.TestCase):
 
     def test_operations_cast_data_types(self):
         """Test that operations class maps AutoFields to uuid for casting."""
-        self.assertEqual(self.ops.cast_data_types['AutoField'], 'uuid')
-        self.assertEqual(self.ops.cast_data_types['BigAutoField'], 'uuid')
+        self.assertEqual(self.ops.cast_data_types["AutoField"], "uuid")
+        self.assertEqual(self.ops.cast_data_types["BigAutoField"], "uuid")
 
     def test_autofield_to_python_uuid_conversion(self):
         """Test that AutoField.to_python converts UUID strings to UUID objects."""
@@ -282,53 +261,59 @@ class TestAuroraDSQLBackend(unittest.TestCase):
 
     def test_disable_server_side_cursors_auto_set(self):
         """Test that DISABLE_SERVER_SIDE_CURSORS is automatically set to True."""
-        wrapper = DatabaseWrapper({
-            'ENGINE': 'aurora_dsql_django',
-            'NAME': 'test_db',
-        })
+        wrapper = DatabaseWrapper(
+            {
+                "ENGINE": "aurora_dsql_django",
+                "NAME": "test_db",
+            }
+        )
 
-        self.assertTrue(wrapper.settings_dict['DISABLE_SERVER_SIDE_CURSORS'])
+        self.assertTrue(wrapper.settings_dict["DISABLE_SERVER_SIDE_CURSORS"])
 
     def test_disable_server_side_cursors_respects_customer_setting(self):
         """Test that customer's DISABLE_SERVER_SIDE_CURSORS setting is not overridden."""
-        wrapper_false = DatabaseWrapper({
-            'ENGINE': 'aurora_dsql_django',
-            'NAME': 'test_db',
-
-            # Explicit user configuration.
-            'DISABLE_SERVER_SIDE_CURSORS': False,
-        })
+        wrapper_false = DatabaseWrapper(
+            {
+                "ENGINE": "aurora_dsql_django",
+                "NAME": "test_db",
+                # Explicit user configuration.
+                "DISABLE_SERVER_SIDE_CURSORS": False,
+            }
+        )
 
         # Ensure we do not override a value that conflicts with the default.
-        self.assertFalse(wrapper_false.settings_dict['DISABLE_SERVER_SIDE_CURSORS'])
+        self.assertFalse(wrapper_false.settings_dict["DISABLE_SERVER_SIDE_CURSORS"])
 
         # Test with customer setting True
-        wrapper_true = DatabaseWrapper({
-            'ENGINE': 'aurora_dsql_django',
-            'NAME': 'test_db',
+        wrapper_true = DatabaseWrapper(
+            {
+                "ENGINE": "aurora_dsql_django",
+                "NAME": "test_db",
+                # Explicit user configuration.
+                "DISABLE_SERVER_SIDE_CURSORS": True,
+            }
+        )
 
-            # Explicit user configuration.
-            'DISABLE_SERVER_SIDE_CURSORS': True,
-        })
-
-        self.assertTrue(wrapper_true.settings_dict['DISABLE_SERVER_SIDE_CURSORS'])
+        self.assertTrue(wrapper_true.settings_dict["DISABLE_SERVER_SIDE_CURSORS"])
 
     def test_disable_server_side_cursors_with_other_options(self):
         """Test that DISABLE_SERVER_SIDE_CURSORS works with other settings."""
-        wrapper = DatabaseWrapper({
-            'ENGINE': 'aurora_dsql_django',
-            'NAME': 'test_db',
-            'OPTIONS': {
-                'sslmode': 'require',
-                'region': 'us-east-1',
+        wrapper = DatabaseWrapper(
+            {
+                "ENGINE": "aurora_dsql_django",
+                "NAME": "test_db",
+                "OPTIONS": {
+                    "sslmode": "require",
+                    "region": "us-east-1",
+                },
             }
-        })
+        )
 
         # Should add DISABLE_SERVER_SIDE_CURSORS while preserving other options
-        self.assertTrue(wrapper.settings_dict['DISABLE_SERVER_SIDE_CURSORS'])
-        self.assertEqual(wrapper.settings_dict['OPTIONS']['sslmode'], 'require')
-        self.assertEqual(wrapper.settings_dict['OPTIONS']['region'], 'us-east-1')
+        self.assertTrue(wrapper.settings_dict["DISABLE_SERVER_SIDE_CURSORS"])
+        self.assertEqual(wrapper.settings_dict["OPTIONS"]["sslmode"], "require")
+        self.assertEqual(wrapper.settings_dict["OPTIONS"]["region"], "us-east-1")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/aurora_dsql_django/tests/unit/test_creation.py
+++ b/aurora_dsql_django/tests/unit/test_creation.py
@@ -1,10 +1,10 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from aurora_dsql_django.creation import DatabaseCreation
 
 
 class TestDatabaseCreation(unittest.TestCase):
-
     def setUp(self):
         # Create a mock connection object
         self.mock_connection = MagicMock()
@@ -12,14 +12,10 @@ class TestDatabaseCreation(unittest.TestCase):
 
     def test_clone_test_db_raises_not_implemented_error(self):
         with self.assertRaises(NotImplementedError) as context:
-            self.creation._clone_test_db(suffix='test', verbosity=1)
+            self.creation._clone_test_db(suffix="test", verbosity=1)
 
-        self.assertIn(
-            "Aurora DSQL doesn't support cloning databases", str(
-                context.exception))
-        self.assertIn(
-            "Disable the option to run tests in parallel processes", str(
-                context.exception))
+        self.assertIn("Aurora DSQL doesn't support cloning databases", str(context.exception))
+        self.assertIn("Disable the option to run tests in parallel processes", str(context.exception))
 
     """
     The 'keepdb' parameter in Django's test database creation process determines whether
@@ -42,20 +38,20 @@ class TestDatabaseCreation(unittest.TestCase):
 
     def test_clone_test_db_with_keepdb(self):
         with self.assertRaises(NotImplementedError):
-            self.creation._clone_test_db(
-                suffix='test', verbosity=1, keepdb=True)
+            self.creation._clone_test_db(suffix="test", verbosity=1, keepdb=True)
 
-    @patch('aurora_dsql_django.creation.creation.DatabaseCreation._clone_test_db')
+    @patch("aurora_dsql_django.creation.creation.DatabaseCreation._clone_test_db")
     def test_parent_clone_test_db_not_called(self, mock_parent_clone):
         with self.assertRaises(NotImplementedError):
-            self.creation._clone_test_db(suffix='test', verbosity=1)
+            self.creation._clone_test_db(suffix="test", verbosity=1)
 
         mock_parent_clone.assert_not_called()
 
     def test_inheritance(self):
         from django.db.backends.postgresql.creation import DatabaseCreation as PostgreSQLDatabaseCreation
+
         self.assertIsInstance(self.creation, PostgreSQLDatabaseCreation)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/aurora_dsql_django/tests/unit/test_features.py
+++ b/aurora_dsql_django/tests/unit/test_features.py
@@ -1,9 +1,9 @@
 import unittest
+
 from aurora_dsql_django.features import DatabaseFeatures
 
 
 class TestDatabaseFeatures(unittest.TestCase):
-
     def setUp(self):
         # DatabaseFeatures usually requires a connection object, but for these tests,
         # we can pass None as we're only checking static attributes
@@ -53,26 +53,20 @@ class TestDatabaseFeatures(unittest.TestCase):
 
     def test_inheritance(self):
         from django.db.backends.postgresql.features import DatabaseFeatures as PostgreSQLDatabaseFeatures
+
         self.assertIsInstance(self.features, PostgreSQLDatabaseFeatures)
 
     def test_overridden_attributes(self):
         from django.db.backends.postgresql.features import DatabaseFeatures as PostgreSQLDatabaseFeatures
+
         postgresql_features = PostgreSQLDatabaseFeatures(None)
 
         # Check that we've actually overridden some attributes
-        self.assertNotEqual(
-            self.features.can_rollback_ddl,
-            postgresql_features.can_rollback_ddl)
-        self.assertNotEqual(
-            self.features.supports_foreign_keys,
-            postgresql_features.supports_foreign_keys)
-        self.assertNotEqual(
-            self.features.can_clone_databases,
-            postgresql_features.can_clone_databases)
-        self.assertNotEqual(
-            self.features.has_native_json_field,
-            postgresql_features.has_native_json_field)
+        self.assertNotEqual(self.features.can_rollback_ddl, postgresql_features.can_rollback_ddl)
+        self.assertNotEqual(self.features.supports_foreign_keys, postgresql_features.supports_foreign_keys)
+        self.assertNotEqual(self.features.can_clone_databases, postgresql_features.can_clone_databases)
+        self.assertNotEqual(self.features.has_native_json_field, postgresql_features.has_native_json_field)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/aurora_dsql_django/tests/unit/test_operations.py
+++ b/aurora_dsql_django/tests/unit/test_operations.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import MagicMock
+
 import django
 from django.conf import settings
 
@@ -12,7 +13,6 @@ from aurora_dsql_django.operations import DatabaseOperations
 
 
 class TestDatabaseOperations(unittest.TestCase):
-
     def setUp(self):
         mock_connection = MagicMock()
         self.ops = DatabaseOperations(mock_connection)
@@ -35,47 +35,45 @@ class TestDatabaseOperations(unittest.TestCase):
 
     def test_inheritance(self):
         from django.db.backends.postgresql.operations import DatabaseOperations as PostgreSQLDatabaseOperations
+
         self.assertIsInstance(self.ops, PostgreSQLDatabaseOperations)
 
     def test_overridden_attributes(self):
         from django.db.backends.postgresql.operations import DatabaseOperations as PostgreSQLDatabaseOperations
+
         postgresql_ops = PostgreSQLDatabaseOperations(None)
 
         # Check that we've actually overridden some attributes
-        self.assertNotEqual(
-            self.ops.cast_data_types,
-            postgresql_ops.cast_data_types)
+        self.assertNotEqual(self.ops.cast_data_types, postgresql_ops.cast_data_types)
 
     def test_cast_data_types_autofield(self):
-        self.assertEqual(self.ops.cast_data_types['AutoField'], 'uuid')
+        self.assertEqual(self.ops.cast_data_types["AutoField"], "uuid")
 
     def test_cast_data_types_bigautofield(self):
-        self.assertEqual(self.ops.cast_data_types['BigAutoField'], 'uuid')
+        self.assertEqual(self.ops.cast_data_types["BigAutoField"], "uuid")
 
     def test_cast_data_types_smallautofield(self):
-        self.assertEqual(
-            self.ops.cast_data_types['SmallAutoField'],
-            'smallint')
+        self.assertEqual(self.ops.cast_data_types["SmallAutoField"], "smallint")
 
     def test_integer_field_range_for_uuid(self):
         """Test that UUIDField returns None for integer field range."""
-        result = self.ops.integer_field_range('UUIDField')
+        result = self.ops.integer_field_range("UUIDField")
         self.assertEqual(result, (None, None))
 
     def test_integer_field_range_for_integer_field(self):
         """Test that IntegerField returns normal integer ranges."""
-        result = self.ops.integer_field_range('IntegerField')
+        result = self.ops.integer_field_range("IntegerField")
         self.assertIsNotNone(result[0], "No min provided")
         self.assertIsNotNone(result[1], "No max provided")
         self.assertTrue(result[0] <= result[1], "min > max")
 
     def test_integer_field_range_for_big_integer_field(self):
         """Test that BigIntegerField returns normal integer ranges."""
-        result = self.ops.integer_field_range('BigIntegerField')
+        result = self.ops.integer_field_range("BigIntegerField")
         self.assertIsNotNone(result[0], "No min provided")
         self.assertIsNotNone(result[1], "No max provided")
         self.assertTrue(result[0] <= result[1], "min > max")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/aurora_dsql_django/tests/unit/test_schema.py
+++ b/aurora_dsql_django/tests/unit/test_schema.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 from django.db.models.constraints import UniqueConstraint
@@ -10,25 +10,23 @@ from aurora_dsql_django.tests.utils import create_check_constraint
 
 
 class TestDatabaseSchemaEditor(unittest.TestCase):
-
     def setUp(self):
         self.connection = MagicMock()
         self.schema_editor = DatabaseSchemaEditor(self.connection)
 
     def test_sql_attributes(self):
-        self.assertEqual(self.schema_editor.sql_create_index,
-                         "CREATE INDEX ASYNC %(name)s ON %(table)s%(using)s (%(columns)s)%(include)s%(extra)s%(condition)s")
-        self.assertEqual(self.schema_editor.sql_create_unique,
-                         "CREATE UNIQUE INDEX ASYNC %(name)s ON %(table)s (%(columns)s)")
         self.assertEqual(
-            self.schema_editor.sql_delete_unique,
-            "DROP INDEX %(name)s CASCADE")
+            self.schema_editor.sql_create_index,
+            "CREATE INDEX ASYNC %(name)s ON %(table)s%(using)s (%(columns)s)%(include)s%(extra)s%(condition)s",
+        )
+        self.assertEqual(self.schema_editor.sql_create_unique, "CREATE UNIQUE INDEX ASYNC %(name)s ON %(table)s (%(columns)s)")
+        self.assertEqual(self.schema_editor.sql_delete_unique, "DROP INDEX %(name)s CASCADE")
         self.assertEqual(
             self.schema_editor.sql_update_with_default,
-            "UPDATE %(table)s SET %(column)s = %(default)s WHERE %(column)s IS NULL"
+            "UPDATE %(table)s SET %(column)s = %(default)s WHERE %(column)s IS NULL",
         )
 
-    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_index')
+    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_index")
     def test_add_index_with_expressions(self, mock_super_add_index):
         model = MagicMock()
         index = MagicMock(contains_expressions=True)
@@ -39,7 +37,7 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
         self.assertIsNone(result)
         mock_super_add_index.assert_not_called()
 
-    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_index')
+    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_index")
     def test_add_index_without_expressions(self, mock_super_add_index):
         model = MagicMock()
         index = MagicMock(contains_expressions=False)
@@ -48,7 +46,7 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
 
         mock_super_add_index.assert_called_once_with(model, index, False)
 
-    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_index')
+    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_index")
     def test_remove_index_with_expressions(self, mock_super_remove_index):
         model = MagicMock()
         index = MagicMock(contains_expressions=True)
@@ -59,7 +57,7 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
         self.assertIsNone(result)
         mock_super_remove_index.assert_not_called()
 
-    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_index')
+    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_index")
     def test_remove_index_without_expressions(self, mock_super_remove_index):
         model = MagicMock()
         index = MagicMock(contains_expressions=False)
@@ -74,12 +72,9 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
         col_suffixes = ["", ""]
         opclasses = ["", ""]
 
-        result = self.schema_editor._index_columns(
-            table, columns, col_suffixes, opclasses)
+        result = self.schema_editor._index_columns(table, columns, col_suffixes, opclasses)
 
-        expected = BaseDatabaseSchemaEditor._index_columns(
-            self.schema_editor, table, columns, col_suffixes, opclasses
-        )
+        expected = BaseDatabaseSchemaEditor._index_columns(self.schema_editor, table, columns, col_suffixes, opclasses)
 
         self.assertIsInstance(result, type(expected))
         self.assertEqual(result.table, expected.table)
@@ -93,87 +88,87 @@ class TestDatabaseSchemaEditor(unittest.TestCase):
 
         self.assertIsNone(result)
 
-    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor._check_sql')
+    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor._check_sql")
     def test_check_sql_feature_disabled(self, mock_super_check_sql):
         self.connection.features.supports_table_check_constraints = False
-        
+
         result = self.schema_editor._check_sql("test_check", "age >= 0")
-        
+
         self.assertIsNone(result)
         mock_super_check_sql.assert_not_called()
 
-    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor._check_sql')
+    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor._check_sql")
     def test_check_sql_feature_enabled(self, mock_super_check_sql):
         self.connection.features.supports_table_check_constraints = True
         mock_super_check_sql.return_value = "CHECK (age >= 0)"
-        
+
         result = self.schema_editor._check_sql("test_check", "age >= 0")
-        
+
         mock_super_check_sql.assert_called_once_with("test_check", "age >= 0")
         self.assertEqual(result, "CHECK (age >= 0)")
 
-    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint')
+    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint")
     def test_add_constraint_check_disabled(self, mock_super_add_constraint):
         model = MagicMock()
-        constraint = create_check_constraint(Q(age__gte=0), 'age_check')
+        constraint = create_check_constraint(Q(age__gte=0), "age_check")
         self.connection.features.supports_table_check_constraints = False
-        
+
         result = self.schema_editor.add_constraint(model, constraint)
-        
+
         self.assertIsNone(result)
         mock_super_add_constraint.assert_not_called()
 
-    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint')
+    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint")
     def test_add_constraint_check_enabled(self, mock_super_add_constraint):
         model = MagicMock()
-        constraint = create_check_constraint(Q(age__gte=0), 'age_check')
+        constraint = create_check_constraint(Q(age__gte=0), "age_check")
         self.connection.features.supports_table_check_constraints = True
-        
+
         self.schema_editor.add_constraint(model, constraint)
-        
+
         mock_super_add_constraint.assert_called_once_with(model, constraint)
 
-    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint')
+    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.add_constraint")
     def test_add_constraint_non_check(self, mock_super_add_constraint):
         model = MagicMock()
-        constraint = UniqueConstraint(fields=['name'], name='unique_name')
+        constraint = UniqueConstraint(fields=["name"], name="unique_name")
         self.connection.features.supports_table_check_constraints = False
-        
+
         self.schema_editor.add_constraint(model, constraint)
-        
+
         mock_super_add_constraint.assert_called_once_with(model, constraint)
 
-    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_constraint')
+    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_constraint")
     def test_remove_constraint_check_disabled(self, mock_super_remove_constraint):
         model = MagicMock()
-        constraint = create_check_constraint(Q(age__gte=0), 'age_check')
+        constraint = create_check_constraint(Q(age__gte=0), "age_check")
         self.connection.features.supports_table_check_constraints = False
-        
+
         result = self.schema_editor.remove_constraint(model, constraint)
-        
+
         self.assertIsNone(result)
         mock_super_remove_constraint.assert_not_called()
 
-    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_constraint')
+    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_constraint")
     def test_remove_constraint_check_enabled(self, mock_super_remove_constraint):
         model = MagicMock()
-        constraint = create_check_constraint(Q(age__gte=0), 'age_check')
+        constraint = create_check_constraint(Q(age__gte=0), "age_check")
         self.connection.features.supports_table_check_constraints = True
-        
+
         self.schema_editor.remove_constraint(model, constraint)
-        
+
         mock_super_remove_constraint.assert_called_once_with(model, constraint)
 
-    @patch('aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_constraint')
+    @patch("aurora_dsql_django.schema.schema.DatabaseSchemaEditor.remove_constraint")
     def test_remove_constraint_non_check(self, mock_super_remove_constraint):
         model = MagicMock()
-        constraint = UniqueConstraint(fields=['name'], name='unique_name')
+        constraint = UniqueConstraint(fields=["name"], name="unique_name")
         self.connection.features.supports_table_check_constraints = False
-        
+
         self.schema_editor.remove_constraint(model, constraint)
-        
+
         mock_super_remove_constraint.assert_called_once_with(model, constraint)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/aurora_dsql_django/tests/unit/test_wrapper.py
+++ b/aurora_dsql_django/tests/unit/test_wrapper.py
@@ -1,10 +1,12 @@
 import unittest
 from unittest.mock import MagicMock, patch
+
 import django
 from django.conf import settings
 from django.db import models
-from django.db.models import CheckConstraint, Q, Index
+from django.db.models import Index, Q
 from django.db.models.functions import Upper
+
 from aurora_dsql_django.base import DatabaseWrapper
 from aurora_dsql_django.features import DatabaseFeatures
 from aurora_dsql_django.schema import DatabaseSchemaEditor
@@ -12,8 +14,8 @@ from aurora_dsql_django.tests.utils import create_check_constraint
 
 if not settings.configured:
     settings.configure(
-        INSTALLED_APPS=['django.contrib.contenttypes'],
-        DATABASES={'default': {'ENGINE': 'aurora_dsql_django'}},
+        INSTALLED_APPS=["django.contrib.contenttypes"],
+        DATABASES={"default": {"ENGINE": "aurora_dsql_django"}},
         USE_TZ=True,
     )
     django.setup()
@@ -42,17 +44,17 @@ class TestWrapper(unittest.TestCase):
             executed_sql.append((sql, params))
 
         # Capture SQL statements without running anything against a real DB.
-        execute_patch = patch.object(self.schema_editor, 'execute', side_effect=mock_execute)
+        execute_patch = patch.object(self.schema_editor, "execute", side_effect=mock_execute)
 
         # Work around issue caused by missing encoding configuration in test environment.
-        quote_patch = patch.object(self.schema_editor, 'quote_value', side_effect=simple_quote_value)
+        quote_patch = patch.object(self.schema_editor, "quote_value", side_effect=simple_quote_value)
 
         with execute_patch, quote_patch:
             with self.schema_editor:
                 operation_func()
 
         all_sql = [str(sql) for sql, _ in executed_sql]
-        if hasattr(self.schema_editor, 'deferred_sql'):
+        if hasattr(self.schema_editor, "deferred_sql"):
             all_sql += [str(sql) for sql in self.schema_editor.deferred_sql]
 
         matching_statements = [sql for sql in all_sql if any(pattern in sql for pattern in sql_patterns)]
@@ -63,22 +65,18 @@ class TestWrapper(unittest.TestCase):
 
         class ParentModel(models.Model):
             class Meta:
-                app_label = 'test_app'
+                app_label = "test_app"
 
         class ChildModel(models.Model):
             parent = models.ForeignKey(ParentModel, on_delete=models.CASCADE)
 
             class Meta:
-                app_label = 'test_app'
+                app_label = "test_app"
 
         def operation():
             self.schema_editor.create_model(ChildModel)
 
-        self._assert_sql_not_generated(
-            operation,
-            ['FOREIGN KEY', 'REFERENCES'],
-            "Should not generate foreign key SQL"
-        )
+        self._assert_sql_not_generated(operation, ["FOREIGN KEY", "REFERENCES"], "Should not generate foreign key SQL")
 
     def test_check_constraint_create_model_ignored(self):
         """Ensure check constraint operations are ignored for model creation when the feature is disabled"""
@@ -87,19 +85,13 @@ class TestWrapper(unittest.TestCase):
             age = models.IntegerField()
 
             class Meta:
-                app_label = 'test_app'
-                constraints = [
-                    create_check_constraint(Q(age__gte=0), 'age_gte_0')
-                ]
+                app_label = "test_app"
+                constraints = [create_check_constraint(Q(age__gte=0), "age_gte_0")]
 
         def operation():
             self.schema_editor.create_model(CheckConstraintModel)
 
-        self._assert_sql_not_generated(
-            operation,
-            ['CHECK'],
-            "Should not generate check constraint SQL"
-        )
+        self._assert_sql_not_generated(operation, ["CHECK"], "Should not generate check constraint SQL")
 
     def test_check_constraint_add_constraint_ignored(self):
         """Ensure add_constraint operations ignore check constraints when the feature is disabled"""
@@ -108,18 +100,14 @@ class TestWrapper(unittest.TestCase):
             age = models.IntegerField()
 
             class Meta:
-                app_label = 'test_app'
+                app_label = "test_app"
 
-        constraint = create_check_constraint(Q(age__gte=0), 'age_gte_0')
+        constraint = create_check_constraint(Q(age__gte=0), "age_gte_0")
 
         def operation():
             self.schema_editor.add_constraint(AddCheckConstraintModel, constraint)
 
-        self._assert_sql_not_generated(
-            operation,
-            ['CHECK'],
-            "Should not execute check constraint SQL"
-        )
+        self._assert_sql_not_generated(operation, ["CHECK"], "Should not execute check constraint SQL")
 
     def test_check_constraint_remove_constraint_ignored(self):
         """Ensure remove_constraint operations ignore check constraints when the feature is disabled"""
@@ -128,19 +116,14 @@ class TestWrapper(unittest.TestCase):
             age = models.IntegerField()
 
             class Meta:
-                app_label = 'test_app'
+                app_label = "test_app"
 
-        constraint = create_check_constraint(Q(age__gte=0), 'age_gte_0')
+        constraint = create_check_constraint(Q(age__gte=0), "age_gte_0")
 
         def operation():
             self.schema_editor.remove_constraint(RemoveCheckConstraintModel, constraint)
 
-        self._assert_sql_not_generated(
-            operation,
-            ['CONSTRAINT'],
-            "Should not execute check constraint removal SQL"
-        )
-
+        self._assert_sql_not_generated(operation, ["CONSTRAINT"], "Should not execute check constraint removal SQL")
 
     def test_add_index_expression_ignored(self):
         """Ensure add_index operations ignore expression indexes when the feature is disabled"""
@@ -149,17 +132,15 @@ class TestWrapper(unittest.TestCase):
             name = models.CharField(max_length=100)
 
             class Meta:
-                app_label = 'test_app'
+                app_label = "test_app"
 
-        expression_index = Index(Upper('name'), name='upper_name_idx')
+        expression_index = Index(Upper("name"), name="upper_name_idx")
 
         def operation():
             self.schema_editor.add_index(AddIndexModel, expression_index)
 
         self._assert_sql_not_generated(
-            operation,
-            ['CREATE INDEX'],
-            "Should not generate index creation SQL for expression indexes"
+            operation, ["CREATE INDEX"], "Should not generate index creation SQL for expression indexes"
         )
 
     def test_remove_index_expression_ignored(self):
@@ -169,19 +150,17 @@ class TestWrapper(unittest.TestCase):
             name = models.CharField(max_length=100)
 
             class Meta:
-                app_label = 'test_app'
+                app_label = "test_app"
 
-        expression_index = Index(Upper('name'), name='upper_name_idx')
+        expression_index = Index(Upper("name"), name="upper_name_idx")
 
         def operation():
             self.schema_editor.remove_index(RemoveIndexModel, expression_index)
 
         self._assert_sql_not_generated(
-            operation,
-            ['DROP INDEX'],
-            "Should not generate index removal SQL for expression indexes"
+            operation, ["DROP INDEX"], "Should not generate index removal SQL for expression indexes"
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,8 +16,9 @@
 
 import os
 
-import aurora_dsql_django
 import guzzle_sphinx_theme
+
+import aurora_dsql_django
 
 # -- General configuration -----------------------------------------------------
 
@@ -26,23 +27,23 @@ import guzzle_sphinx_theme
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ".rst"
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'
 
 # The master toctree document.
-master_doc = 'index'
+master_doc = "index"
 
 # General information about the project.
-project = 'AuroraDSQL Docs'
-copyright = 'Amazon Web Services, Inc'
+project = "AuroraDSQL Docs"
+copyright = "Amazon Web Services, Inc"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -82,21 +83,21 @@ exclude_patterns = []
 # show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = "sphinx"
 
 # A list of ignored prefixes for module index sorting.
 # modindex_common_prefix = []
 
 extensions.append("guzzle_sphinx_theme")
-html_translator_class = 'guzzle_sphinx_theme.HTMLTranslator'
+html_translator_class = "guzzle_sphinx_theme.HTMLTranslator"
 html_theme_path = guzzle_sphinx_theme.html_theme_path()
-html_theme = 'guzzle_sphinx_theme'
+html_theme = "guzzle_sphinx_theme"
 # Guzzle theme options (see theme.conf for more information)
 
 html_theme_options = {
     # hack to add tracking
-    "google_analytics_account": os.getenv('TRACKING', False),
-    "base_url": "http://docs.aws.amazon.com/aws-sdk-php/guide/latest/"
+    "google_analytics_account": os.getenv("TRACKING", False),
+    "base_url": "http://docs.aws.amazon.com/aws-sdk-php/guide/latest/",
 }
 
 # -- Options for HTML output ---------------------------------------------------
@@ -132,10 +133,10 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
 html_css_files = [
-    'css/custom.css',
+    "css/custom.css",
 ]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
@@ -148,11 +149,7 @@ html_css_files = [
 
 # Custom sidebar templates, maps document names to template names.
 html_show_sourcelink = False
-html_sidebars = {
-    '**': ['logo-text.html',
-           'globaltoc.html',
-           'searchbox.html']
-}
+html_sidebars = {"**": ["logo-text.html", "globaltoc.html", "searchbox.html"]}
 
 # Additional templates that should be rendered to pages, maps page names to
 # template names.
@@ -185,7 +182,7 @@ html_sidebars = {
 # html_file_suffix = None
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'AuroraDSQLdoc'
+htmlhelp_basename = "AuroraDSQLdoc"
 
 
 # -- Options for LaTeX output --------------------------------------------------
@@ -202,8 +199,7 @@ latex_elements = {}
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'AuroraDSQL.tex', 'AuroraDSQL Documentation',
-   'Amazon.com, Inc.', 'manual'),
+    ("index", "AuroraDSQL.tex", "AuroraDSQL Documentation", "Amazon.com, Inc.", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -231,10 +227,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [
-    ('index', 'AuroraDSQL', 'AuroraDSQL Documentation',
-     ['Amazon.com, Inc.'], 1)
-]
+man_pages = [("index", "AuroraDSQL", "AuroraDSQL Documentation", ["Amazon.com, Inc."], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -246,9 +239,15 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'AuroraDSQL', 'AuroraDSQL Documentation',
-   'Amazon.com, Inc.', 'AuroraDSQL', 'One line description of project.',
-   'Miscellaneous'),
+    (
+        "index",
+        "AuroraDSQL",
+        "AuroraDSQL Documentation",
+        "Amazon.com, Inc.",
+        "AuroraDSQL",
+        "One line description of project.",
+        "Miscellaneous",
+    ),
 ]
 
 # Documents to append as an appendix to all manuals.
@@ -260,4 +259,4 @@ texinfo_documents = [
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
 
-autoclass_content = 'both'
+autoclass_content = "both"

--- a/examples/pet-clinic-app/project/manage.py
+++ b/examples/pet-clinic-app/project/manage.py
@@ -12,13 +12,14 @@
 # and limitations under the License.
 
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 
 
 def main():
     """Run administrative tasks."""
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:
@@ -30,5 +31,5 @@ def main():
     execute_from_command_line(sys.argv)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/examples/pet-clinic-app/project/pet_clinic/apps.py
+++ b/examples/pet-clinic-app/project/pet_clinic/apps.py
@@ -13,5 +13,5 @@ from django.apps import AppConfig
 
 
 class PetClinicConfig(AppConfig):
-    default_auto_field = 'django.db.models.BigAutoField'
-    name = 'pet_clinic'
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "pet_clinic"

--- a/examples/pet-clinic-app/project/pet_clinic/models.py
+++ b/examples/pet-clinic-app/project/pet_clinic/models.py
@@ -9,33 +9,26 @@
 # CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
 # and limitations under the License.
 
-from django.db import models
 import uuid
+
+from django.db import models
 
 # Create your models here.
 
 
 class Owner(models.Model):
-    id = models.UUIDField(
-        primary_key=True,
-        default=uuid.uuid4,
-        editable=False
-    )
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=30, blank=False)
     # This is many to one relation
     city = models.CharField(max_length=80, blank=False)
     telephone = models.CharField(max_length=20, blank=True, null=True, default=None)
 
     def __str__(self):
-        return f'{self.name}'
+        return f"{self.name}"
 
 
 class Pet(models.Model):
-    id = models.UUIDField(
-        primary_key=True,
-        default=uuid.uuid4,
-        editable=False
-    )
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=30, blank=False)
     birth_date = models.DateField()
     owner = models.ForeignKey(Owner, on_delete=models.CASCADE, db_constraint=False, null=True)
@@ -49,37 +42,25 @@ class Specialty(models.Model):
 
 
 class Vet(models.Model):
-    id = models.UUIDField(
-        primary_key=True,
-        default=uuid.uuid4,
-        editable=False
-    )
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=30, blank=False)
-    specialties = models.ManyToManyField(Specialty, through='VetSpecialties')
+    specialties = models.ManyToManyField(Specialty, through="VetSpecialties")
     owner = models.OneToOneField(Owner, on_delete=models.SET_DEFAULT, db_constraint=False, null=True, blank=True, default=None)
 
     def __str__(self):
-        return f'{self.name}'
+        return f"{self.name}"
 
 
 # Need to use custom intermediate table because Django considers default primary
 # keys as integers. We use UUID as default primary key which is not an integer.
 class VetSpecialties(models.Model):
-    id = models.UUIDField(
-        primary_key=True,
-        default=uuid.uuid4,
-        editable=False
-    )
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     vet = models.ForeignKey(Vet, on_delete=models.CASCADE, db_constraint=False)
     specialty = models.ForeignKey(Specialty, on_delete=models.CASCADE, db_constraint=False)
 
 
 class Visits(models.Model):
-    id = models.UUIDField(
-        primary_key=True,
-        default=uuid.uuid4,
-        editable=False
-    )
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     pet = models.ForeignKey(Pet, on_delete=models.CASCADE, db_constraint=False)
     vet = models.ForeignKey(Vet, on_delete=models.CASCADE, db_constraint=False)
     visit_date = models.DateField()

--- a/examples/pet-clinic-app/project/project/asgi.py
+++ b/examples/pet-clinic-app/project/project/asgi.py
@@ -22,6 +22,6 @@ import os
 
 from django.core.asgi import get_asgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
 
 application = get_asgi_application()

--- a/examples/pet-clinic-app/project/project/settings.py
+++ b/examples/pet-clinic-app/project/project/settings.py
@@ -33,48 +33,45 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = ["*"]
 
 
 # Application definition
 
-INSTALLED_APPS = ['pet_clinic']
+INSTALLED_APPS = ["pet_clinic"]
 
 MIDDLEWARE = []
 
-ROOT_URLCONF = 'project.urls'
+ROOT_URLCONF = "project.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
             ],
         },
     },
 ]
 
-WSGI_APPLICATION = 'project.wsgi.application'
+WSGI_APPLICATION = "project.wsgi.application"
 
-SECRET_KEY = 'foobar_this_is_not_relevant_and_unused'  # nosec
+SECRET_KEY = "foobar_this_is_not_relevant_and_unused"  # nosec
 
 # Database
 # https://docs.djangoproject.com/en/5.1/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'HOST': 'luabttng4i6jdbng53eorltjc4.dsql-gamma.us-east-1.on.aws',
-        'USER': 'admin',
-        'NAME': 'postgres',
-        'ENGINE': 'aurora_dsql_django',
-        'OPTIONS': {
-            'sslmode': 'require',
-            'region': 'us-east-1'
-        }
+    "default": {
+        "HOST": "luabttng4i6jdbng53eorltjc4.dsql-gamma.us-east-1.on.aws",
+        "USER": "admin",
+        "NAME": "postgres",
+        "ENGINE": "aurora_dsql_django",
+        "OPTIONS": {"sslmode": "require", "region": "us-east-1"},
     }
 }
 
@@ -84,16 +81,16 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
     },
 ]
 
@@ -101,9 +98,9 @@ AUTH_PASSWORD_VALIDATORS = [
 # Internationalization
 # https://docs.djangoproject.com/en/5.1/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 
@@ -113,9 +110,9 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/5.1/howto/static-files/
 
-STATIC_URL = 'static/'
+STATIC_URL = "static/"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.1/ref/settings/#default-auto-field
 
-DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/examples/pet-clinic-app/project/project/urls.py
+++ b/examples/pet-clinic-app/project/project/urls.py
@@ -25,21 +25,18 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.urls import path
-from pet_clinic.views import OwnerView
-from pet_clinic.views import PetView
-from pet_clinic.views import VetView
-from pet_clinic.views import SpecialtyView
-from pet_clinic.views import VetSpecialtiesView
+from pet_clinic.views import OwnerView, PetView, SpecialtyView, VetSpecialtiesView, VetView
 
 urlpatterns = [
-    path('owner/', OwnerView.as_view(), name='owner'),
-    path('owner/<id>', OwnerView.as_view(), name='owner'),
-    path('pet/', PetView.as_view(), name='pet'),
-    path('pet/<id>', PetView.as_view(), name='pet'),
-    path('vet/', VetView.as_view(), name='vet'),
-    path('vet/<id>', VetView.as_view(), name='vet'),
-    path('specialty/', SpecialtyView.as_view(), name='specialty'),
-    path('specialty/<name>', SpecialtyView.as_view(), name='specialty'),
-    path('vet-specialties/', VetSpecialtiesView.as_view(), name='vet-specialties'),
+    path("owner/", OwnerView.as_view(), name="owner"),
+    path("owner/<id>", OwnerView.as_view(), name="owner"),
+    path("pet/", PetView.as_view(), name="pet"),
+    path("pet/<id>", PetView.as_view(), name="pet"),
+    path("vet/", VetView.as_view(), name="vet"),
+    path("vet/<id>", VetView.as_view(), name="vet"),
+    path("specialty/", SpecialtyView.as_view(), name="specialty"),
+    path("specialty/<name>", SpecialtyView.as_view(), name="specialty"),
+    path("vet-specialties/", VetSpecialtiesView.as_view(), name="vet-specialties"),
 ]

--- a/examples/pet-clinic-app/project/project/wsgi.py
+++ b/examples/pet-clinic-app/project/project/wsgi.py
@@ -22,6 +22,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
 
 application = get_wsgi_application()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ test = [
 ]
 dev = [
     "flake8",
+    "ruff",
     "Sphinx>=7.1.0,<8.0.0",
     "docutils>=0.18.0,<0.21.0",
     "pip>=24.3.1,<25.0.0",
@@ -53,3 +54,18 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["aurora_dsql_django*"]
+
+[tool.ruff]
+indent-width = 4
+target-version = "py38"
+
+# Aligns with flake8 check in CI/CD workflow.
+line-length = 127
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I"]
+ignore = []
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/uv.lock
+++ b/uv.lock
@@ -84,6 +84,7 @@ dev = [
     { name = "flake8", version = "7.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "guzzle-sphinx-theme" },
     { name = "pip" },
+    { name = "ruff" },
     { name = "setuptools", version = "75.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
     { name = "setuptools", version = "80.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
     { name = "setuptools-scm" },
@@ -115,6 +116,7 @@ requires-dist = [
     { name = "psycopg2-binary", marker = "extra == 'test'" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8" },
     { name = "pytest-cov", marker = "extra == 'test'" },
+    { name = "ruff", marker = "extra == 'dev'" },
     { name = "setuptools", marker = "extra == 'dev'", specifier = ">=61.0" },
     { name = "setuptools-scm", marker = "extra == 'dev'", specifier = ">=8" },
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=7.1.0,<8.0.0" },
@@ -1230,6 +1232,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/df/8d7d8c515d33adfc540e2edf6c6021ea1c5a58a678d8cfce9fae59aabcab/ruff-0.13.2.tar.gz", hash = "sha256:cb12fffd32fb16d32cef4ed16d8c7cdc27ed7c944eaa98d99d01ab7ab0b710ff", size = 5416417, upload-time = "2025-09-25T14:54:09.936Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/84/5716a7fa4758e41bf70e603e13637c42cfb9dbf7ceb07180211b9bbf75ef/ruff-0.13.2-py3-none-linux_armv6l.whl", hash = "sha256:3796345842b55f033a78285e4f1641078f902020d8450cade03aad01bffd81c3", size = 12343254, upload-time = "2025-09-25T14:53:27.784Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/77/c7042582401bb9ac8eff25360e9335e901d7a1c0749a2b28ba4ecb239991/ruff-0.13.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ff7e4dda12e683e9709ac89e2dd436abf31a4d8a8fc3d89656231ed808e231d2", size = 13040891, upload-time = "2025-09-25T14:53:31.38Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/15/125a7f76eb295cb34d19c6778e3a82ace33730ad4e6f28d3427e134a02e0/ruff-0.13.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c75e9d2a2fafd1fdd895d0e7e24b44355984affdde1c412a6f6d3f6e16b22d46", size = 12243588, upload-time = "2025-09-25T14:53:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/eb/0093ae04a70f81f8be7fd7ed6456e926b65d238fc122311293d033fdf91e/ruff-0.13.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cceac74e7bbc53ed7d15d1042ffe7b6577bf294611ad90393bf9b2a0f0ec7cb6", size = 12491359, upload-time = "2025-09-25T14:53:35.892Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fe/72b525948a6956f07dad4a6f122336b6a05f2e3fd27471cea612349fedb9/ruff-0.13.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6ae3f469b5465ba6d9721383ae9d49310c19b452a161b57507764d7ef15f4b07", size = 12162486, upload-time = "2025-09-25T14:53:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/e3/0fac422bbbfb2ea838023e0d9fcf1f30183d83ab2482800e2cb892d02dfe/ruff-0.13.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4f8f9e3cd6714358238cd6626b9d43026ed19c0c018376ac1ef3c3a04ffb42d8", size = 13871203, upload-time = "2025-09-25T14:53:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/82/b721c8e3ec5df6d83ba0e45dcf00892c4f98b325256c42c38ef136496cbf/ruff-0.13.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:c6ed79584a8f6cbe2e5d7dbacf7cc1ee29cbdb5df1172e77fbdadc8bb85a1f89", size = 14929635, upload-time = "2025-09-25T14:53:43.953Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a0/ad56faf6daa507b83079a1ad7a11694b87d61e6bf01c66bd82b466f21821/ruff-0.13.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aed130b2fde049cea2019f55deb939103123cdd191105f97a0599a3e753d61b0", size = 14338783, upload-time = "2025-09-25T14:53:46.205Z" },
+    { url = "https://files.pythonhosted.org/packages/47/77/ad1d9156db8f99cd01ee7e29d74b34050e8075a8438e589121fcd25c4b08/ruff-0.13.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1887c230c2c9d65ed1b4e4cfe4d255577ea28b718ae226c348ae68df958191aa", size = 13355322, upload-time = "2025-09-25T14:53:48.164Z" },
+    { url = "https://files.pythonhosted.org/packages/64/8b/e87cfca2be6f8b9f41f0bb12dc48c6455e2d66df46fe61bb441a226f1089/ruff-0.13.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5bcb10276b69b3cfea3a102ca119ffe5c6ba3901e20e60cf9efb53fa417633c3", size = 13354427, upload-time = "2025-09-25T14:53:50.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/df/bf382f3fbead082a575edb860897287f42b1b3c694bafa16bc9904c11ed3/ruff-0.13.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:afa721017aa55a555b2ff7944816587f1cb813c2c0a882d158f59b832da1660d", size = 13537637, upload-time = "2025-09-25T14:53:52.887Z" },
+    { url = "https://files.pythonhosted.org/packages/51/70/1fb7a7c8a6fc8bd15636288a46e209e81913b87988f26e1913d0851e54f4/ruff-0.13.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:1dbc875cf3720c64b3990fef8939334e74cb0ca65b8dbc61d1f439201a38101b", size = 12340025, upload-time = "2025-09-25T14:53:54.88Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/27/1e5b3f1c23ca5dd4106d9d580e5c13d9acb70288bff614b3d7b638378cc9/ruff-0.13.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5b939a1b2a960e9742e9a347e5bbc9b3c3d2c716f86c6ae273d9cbd64f193f22", size = 12133449, upload-time = "2025-09-25T14:53:57.089Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/09/b92a5ccee289f11ab128df57d5911224197d8d55ef3bd2043534ff72ca54/ruff-0.13.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:50e2d52acb8de3804fc5f6e2fa3ae9bdc6812410a9e46837e673ad1f90a18736", size = 13051369, upload-time = "2025-09-25T14:53:59.124Z" },
+    { url = "https://files.pythonhosted.org/packages/89/99/26c9d1c7d8150f45e346dc045cc49f23e961efceb4a70c47dea0960dea9a/ruff-0.13.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3196bc13ab2110c176b9a4ae5ff7ab676faaa1964b330a1383ba20e1e19645f2", size = 13523644, upload-time = "2025-09-25T14:54:01.622Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/00/e7f1501e81e8ec290e79527827af1d88f541d8d26151751b46108978dade/ruff-0.13.2-py3-none-win32.whl", hash = "sha256:7c2a0b7c1e87795fec3404a485096bcd790216c7c146a922d121d8b9c8f1aaac", size = 12245990, upload-time = "2025-09-25T14:54:03.647Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/bd/d9f33a73de84fafd0146c6fba4f497c4565fe8fa8b46874b8e438869abc2/ruff-0.13.2-py3-none-win_amd64.whl", hash = "sha256:17d95fb32218357c89355f6f6f9a804133e404fc1f65694372e02a557edf8585", size = 13324004, upload-time = "2025-09-25T14:54:06.05Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/12/28fa2f597a605884deb0f65c1b1ae05111051b2a7030f5d8a4ff7f4599ba/ruff-0.13.2-py3-none-win_arm64.whl", hash = "sha256:da711b14c530412c827219312b7d7fbb4877fb31150083add7e8c5336549cea7", size = 12484437, upload-time = "2025-09-25T14:54:08.022Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds `ruff` configuration to enforce code formatting for the project. This will make contributions more consistent and prevent formatting discussions in PRs.

Note the PR has separate commits for the formatting change and the `ruff` configuration. It will be easier to look at the configuration commit directly to block out the formatting noise.

I will add a `.git-blame-ignore-revs` file in a future change once this has been merged and the SHA is finalized.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
