### PR TITLE
Ignore ruff formatting commit during git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# ruff formatting commit
+495c926379696b61ee47dad4921606ba773cd42d


### PR DESCRIPTION
This PR ignores the merged commit from #64.

This will prevent `git blame` from being polluted by the sweeping changes in the auto-formatting commit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
