### PR TITLE
Add Django version matrix testing to CI/CD workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,16 +15,42 @@ on:
 
 jobs:
   integration-tests:
-    name: Python v${{ matrix.version }}
-    runs-on: ubuntu-latest        
+    name: Python v${{ matrix.python-version }} - Django ${{ matrix.django-version }}
+    runs-on: ubuntu-latest
     strategy:
       # If we run more than one job at a time, we will have to have one cluster
       # for each flavor of the job. Otherwise they will interfere with each other
       # These tests are quite fast. We don't need to have many clusters.
       max-parallel: 1
       matrix:
-        # Run test for every python version we intend to support.
-        version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        # Run test for every Python and Django version we intend to support.
+        python-version:
+          - '3.8'
+          - '3.9'
+          - '3.10'
+          - '3.11'
+          - '3.12'
+          - '3.13'
+        django-version:
+          - 'default'
+          - '>=4.2,<4.3'
+          - '>=5.0,<5.1'
+          - '>=5.1,<5.2'
+          - '>=5.2,<5.3'
+        exclude:
+          # Django 5.0+ requires Python 3.10+
+          - python-version: '3.8'
+            django-version: '>=5.0,<5.1'
+          - python-version: '3.8'
+            django-version: '>=5.1,<5.2'
+          - python-version: '3.8'
+            django-version: '>=5.2,<5.3'
+          - python-version: '3.9'
+            django-version: '>=5.0,<5.1'
+          - python-version: '3.9'
+            django-version: '>=5.1,<5.2'
+          - python-version: '3.9'
+            django-version: '>=5.2,<5.3'
     permissions:
       id-token: write
       contents: read
@@ -36,14 +62,11 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
-      # with:
-      #   # For pull requests, check out the base branch, not the PR branch
-      #   ref: ${{ github.event.pull_request.base.sha }}
 
-    - name: Set up Python ${{ matrix.version }}
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v6
       with:
-        python-version: ${{ matrix.version }}
+        python-version: ${{ matrix.python-version }}
 
     - name: Install uv
       uses: astral-sh/setup-uv@v6
@@ -57,8 +80,18 @@ jobs:
     - name: Setup dependencies
       run: |
         uv sync --extra test --extra dev
-        uv run python3 -c "import boto3; print(boto3.__version__)"
+        uv run python -c "import boto3; print(boto3.__version__)"
         echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
+
+    # Install specific Django version for matrix testing, skip for 'default' to verify pyproject.toml version
+    - name: Install Django ${{ matrix.django-version }}
+      if: matrix.django-version != 'default'
+      run: |
+        uv pip install "django${{ matrix.django-version }}"
+
+    - name: Print Django version
+      run: |
+        uv run python -c "import django; print(f'Django version: {django.get_version()}')"
 
     - name: Lint with ruff
       run: |
@@ -79,17 +112,17 @@ jobs:
         DJANGO_SETTINGS_MODULE: aurora_dsql_django.tests.test_settings
       run: |
         uv run pytest --cov=aurora_dsql_django aurora_dsql_django/tests/unit/ --cov-report=xml
-  
+
     - name: Debug test results
       if: always()
       run: |
         cat coverage.xml || echo "coverage.xml not found"
-  
+
     - name: Archive code coverage results
       uses: actions/upload-artifact@v4
       with:
-        name: code-coverage-report
-        path: coverage-v${{ matrix.version }}.xml
+        name: code-coverage-report-${{ github.job }}-${{ strategy.job-index }}
+        path: coverage.xml
 
     - name: Run integration tests
       env:

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ This is the adapter for enabling development of Django applications using Aurora
 
 ## Requirements
 
+### Django
+
+Aurora DSQL adapter for Django supports Django 4.2+ with the following versions:
+- Django 4.2.x (LTS)
+- Django 5.0.x
+- Django 5.1.x
+- Django 5.2.x (LTS)
+
 ### Boto3
 
 Aurora DSQL Django adapter needs boto3 to work. Follow the Boto3 [installation guide](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html) to install Boto3

--- a/aurora_dsql_django/tests/utils.py
+++ b/aurora_dsql_django/tests/utils.py
@@ -7,7 +7,7 @@ from django.db.models import CheckConstraint
 # noinspection PyArgumentList
 def create_check_constraint(condition, name):
     """Create CheckConstraint with Django version compatibility"""
-    if django.VERSION >= (5, 0):
+    if django.VERSION >= (5, 1):
         return CheckConstraint(condition=condition, name=name)
     else:
         return CheckConstraint(check=condition, name=name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,11 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Framework :: Django",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
 ]
 
 [project.urls]
@@ -28,7 +33,7 @@ Repository = "https://github.com/awslabs/aurora-dsql-django"
 [project.optional-dependencies]
 test = [
     "pytest>=8",
-    "django>=4.2.16",
+    "django>=4.2",
     "wheel",
     "psycopg2-binary",
     "psycopg",

--- a/uv.lock
+++ b/uv.lock
@@ -107,7 +107,7 @@ test = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.35.74,<2" },
     { name = "botocore", specifier = ">=1.35.74,<2" },
-    { name = "django", marker = "extra == 'test'", specifier = ">=4.2.16" },
+    { name = "django", marker = "extra == 'test'", specifier = ">=4.2" },
     { name = "docutils", marker = "extra == 'dev'", specifier = ">=0.18.0,<0.21.0" },
     { name = "flake8", marker = "extra == 'dev'" },
     { name = "guzzle-sphinx-theme", marker = "extra == 'dev'", specifier = "~=0.7.11" },
@@ -122,7 +122,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=7.1.0,<8.0.0" },
     { name = "wheel", marker = "extra == 'test'" },
 ]
-provides-extras = ["dev", "test"]
+provides-extras = ["test", "dev"]
 
 [[package]]
 name = "babel"


### PR DESCRIPTION
This PR makes the supported Django versions explicit for the project.

This includes the following changes:
- Add Django to the matrix tests to build and test for each Python version and each Django version
- Add supported Django versions to `README.md`
- Fixed incorrect version check in `utils.py`
- Publish `Framework` metadata for PyPI
- Modify `django` dev requirement version to be more general

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
