### PR TITLE
Remove extra README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,10 +77,6 @@ For more info follow the [Aurora DSQL with Django example](examples/pet-clinic-a
 
 ## Development
 
-### Setup
-
-## Development
-
 Install [uv](https://docs.astral.sh/uv/getting-started/installation/) and then:
 
 ```


### PR DESCRIPTION
I just noticed the `Development` heading appears twice, so this PR removes the extra.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
