### PR TITLE
Replace relative links in markdown files during build

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,5 +1,8 @@
 name: CI/CD
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ version-0 ]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -14,6 +14,17 @@ on:
         type: string
 
 jobs:
+  validate-build:
+    name: Validate build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v5
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+    - name: Build
+      run: uv build
+
   integration-tests:
     name: Python v${{ matrix.python-version }} - Django ${{ matrix.django-version }}
     runs-on: ubuntu-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,7 @@
 [project]
 name = "aurora_dsql_django"
-dynamic = ["version"]
+dynamic = ["version", "readme"]
 description = "Aurora DSQL adapter for Django"
-readme = "README.md"
 license = {text = "Apache License 2.0"}
 authors = [{name = "Amazon Web Services"}]
 requires-python = ">=3.8"

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import re
+
 from setuptools import setup
 from setuptools_scm import get_version
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+import re
+from setuptools import setup
+from setuptools_scm import get_version
+
+GITHUB_URL = "https://github.com/awslabs/aurora-dsql-django"
+version = get_version()
+
+# Use default branch for dev versions, tag for releases.
+if "dev" in version:
+    ref = "version-0"
+else:
+    ref = f"v{version}"
+
+readme_content = open("README.md").read()
+
+
+def convert_relative_link(match):
+    link_text = match.group(1)
+    old_url = match.group(2)
+    if old_url.startswith("./") or old_url.startswith("../"):
+        raise ValueError(f"Relative links starting with './' or '../' are not allowed: {old_url}")
+    new_url = f"{GITHUB_URL}/blob/{ref}/{old_url}"
+    print(f"Converting: {old_url} -> {new_url}")
+    return f"[{link_text}]({new_url})"
+
+
+# Links on PyPI require absolute URLs. Replace relative URLs with absolute ones.
+long_description = re.sub(
+    r"\[([^]]+)]\(((?!https?:)[^)]+)\)",
+    convert_relative_link,
+    readme_content,
+)
+
+setup(long_description=long_description)


### PR DESCRIPTION
This PR modifies the package build to replace relative markdown links with absolute ones.

This is required for PyPI as the relative links do not work properly on the release page. See [this page](https://pypi.org/project/aurora-dsql-django/0.2.0/), which uses `https://pypi.org/project/aurora-dsql-django/0.2.0/reference/KNOWN_ISSUES.md` for the "Known Issues" link instead of a link to the GitHub repo.

I also added an additional step to the CI/CD workflow, since it was not verifying the `uv build` for PRs. This is a good additional step to make sure we don't break something in the release process. It is especially relevant now since it will catch relative links that use `./` or `../` as soon as they are introduced. We could technically support these kinds of relative links but we don't use them right now and it's easier to worry about that if/when we need them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
