### PR TITLE
Clone whole repo for tag metadata

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v5
+      with:
+        fetch-depth: 0
     - name: Install uv
       uses: astral-sh/setup-uv@v6
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+          fetch-depth: 0
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Build


### PR DESCRIPTION
This PR fixes a warning that occurs during the release build by cloning the repo with all history.

```
/home/runner/work/_temp/setup-uv-cache/.../lib/python3.12/site-packages/setuptools_scm/git.py:202:
UserWarning: "/home/runner/work/aurora-dsql-django/aurora-dsql-django" is shallow and may cause errors
```

I think the warning is harmless in practice since the tag information is able to be retrieved based on the successful release, but this should prevent the warning and any future potential issues.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
