### PR TITLE
Add content type to PyPI description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,4 @@ long_description = re.sub(
     readme_content,
 )
 
-setup(
-    long_description=long_description,
-    long_description_content_type="text/markdown"
-)
+setup(long_description=long_description, long_description_content_type="text/markdown")

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,7 @@ long_description = re.sub(
     readme_content,
 )
 
-setup(long_description=long_description)
+setup(
+    long_description=long_description,
+    long_description_content_type="text/markdown"
+)


### PR DESCRIPTION
This PR fixes the release build by correctly identifying the content type of the description.

The previous release to PyPI failed since the content type was not provided and PyPI could not determine it automatically.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
