### PR TITLE
Fix license deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "aurora_dsql_django"
 dynamic = ["version", "readme"]
 description = "Aurora DSQL adapter for Django"
-license = {text = "Apache License 2.0"}
+license-files = ["LICENSE"]
 authors = [{name = "Amazon Web Services"}]
 requires-python = ">=3.9"
 dependencies = [
@@ -11,7 +11,6 @@ dependencies = [
 ]
 classifiers = [
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
This PR fixes the following build warnings:

```
/home/runner/work/.../lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:82:
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also
        use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
```

```
/home/runner/work/.../lib/python3.12/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: 
SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: Apache Software License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
```

We were previously stuck specifying the license using the old method until #74 was merged, since we could not upgrade `setuptools` to a version which supported the newer approach. Now Python 3.8 is no longer supported by the project, we can use the newer method of specifying the license to avoid these warnings.

This has the double benefit of having a single source of truth for the license, since we are delegating it to the existing `LICENSE` file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
