### PR TITLE
Add missing badges (GitHub, Discord and License)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Aurora DSQL adapter for Django
 
-[![PyPI - Version](https://img.shields.io/pypi/v/aurora-dsql-django?style=for-the-badge)](https://pypi.org/project/aurora-dsql-django) [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=for-the-badge)](https://discord.com/invite/nEF6ksFWru)
+[![GitHub](https://img.shields.io/badge/github-awslabs/aurora--dsql--django-blue?logo=github)](https://github.com/awslabs/aurora-dsql-django)
+[![License](https://img.shields.io/badge/license-Apache--2.0-brightgreen)]([LICENSE](https://github.com/awslabs/aurora-dsql-django/blob/main/LICENSE))
+[![PyPI - Version](https://img.shields.io/pypi/v/aurora-dsql-django)](https://pypi.org/project/aurora-dsql-django)
+[![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord)](https://discord.com/invite/nEF6ksFWru)
 
 This is the adapter for enabling development of Django applications using Aurora DSQL.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aurora DSQL adapter for Django
 
-<a href="https://pypi.org/project/aurora-dsql-django"><img alt="PyPI - Version" src="https://img.shields.io/pypi/v/aurora-dsql-django?style=for-the-badge"></a>
+[![PyPI - Version](https://img.shields.io/pypi/v/aurora-dsql-django?style=for-the-badge)](https://pypi.org/project/aurora-dsql-django) [![Discord chat](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=for-the-badge)](https://discord.com/invite/nEF6ksFWru)
 
 This is the adapter for enabling development of Django applications using Aurora DSQL.
 


### PR DESCRIPTION
Add the following badges:
* GitHub (easy access from embedded pages like PyPI)
* License
* Discord badge


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
