### PR TITLE
Allow CI/CD workflows to run in parallel without conflicts

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,13 +7,7 @@ on:
     branches: [ version-0 ]
   pull_request:
     branches: [ version-0 ]
-  # Give us a button to allow running the workflow on demand for testing.
   workflow_dispatch:
-    inputs:
-      tags:
-        description: 'Manual Workflow Run'
-        required: false
-        type: string
 
 jobs:
   validate-build:
@@ -29,8 +23,18 @@ jobs:
     - name: Build
       run: uv build
 
+  create-cluster:
+    uses: ./.github/workflows/dsql-cluster-create.yml
+    with:
+      workflow_name: django-integ
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.DJANGO_ADAPTER_INTEGRATION_TEST_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
   integration-tests:
     name: Python v${{ matrix.python-version }} - Django ${{ matrix.django-version }}
+    needs: create-cluster
     runs-on: ubuntu-latest
     permissions:
       id-token: write # required by aws-actions/configure-aws-credentials
@@ -70,7 +74,7 @@ jobs:
       uses: aws-actions/configure-aws-credentials@v5
       with:
         role-to-assume: ${{ secrets.DJANGO_ADAPTER_INTEGRATION_TEST_ROLE }}
-        aws-region: us-east-1
+        aws-region: ${{ needs.create-cluster.outputs.region }}
 
     - name: Setup dependencies
       run: |
@@ -121,7 +125,18 @@ jobs:
     - name: Run integration tests
       env:
         DJANGO_SETTINGS_MODULE: aurora_dsql_django.tests.test_settings
-        CLUSTER_ENDPOINT: ${{ secrets.CLUSTER_ENDPOINT }}
+        CLUSTER_ENDPOINT: ${{ needs.create-cluster.outputs.cluster-endpoint }}
       run: |
         uv run pytest -v aurora_dsql_django/tests/integration/
-        
+
+  delete-cluster:
+    if: always() && needs.create-cluster.result == 'success'
+    needs: [create-cluster, integration-tests]
+    uses: ./.github/workflows/dsql-cluster-delete.yml
+    with:
+      cluster-id: ${{ needs.create-cluster.outputs.cluster-id }}
+      region: ${{ needs.create-cluster.outputs.region }}
+    secrets:
+      AWS_IAM_ROLE: ${{ secrets.DJANGO_ADAPTER_INTEGRATION_TEST_ROLE }}
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials

--- a/.github/workflows/dsql-cluster-create.yml
+++ b/.github/workflows/dsql-cluster-create.yml
@@ -1,0 +1,75 @@
+name: Create Aurora DSQL Cluster
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      workflow_name:
+        required: true
+        type: string
+        description: 'Name of the calling workflow (used for cluster naming)'
+    secrets:
+      AWS_IAM_ROLE:
+        required: true
+    outputs:
+      cluster-id:
+        description: 'The cluster identifier'
+        value: ${{ jobs.create.outputs.cluster-id }}
+      cluster-endpoint:
+        description: 'The cluster endpoint'
+        value: ${{ jobs.create.outputs.cluster-endpoint }}
+      region:
+        description: 'The AWS region'
+        value: ${{ jobs.create.outputs.region }}
+
+env:
+  AWS_REGION: us-east-1
+  MAX_RETRIES: 5
+  INITIAL_BACKOFF: 10
+
+jobs:
+  create:
+    name: Create Aurora DSQL Cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+    outputs:
+      cluster-id: ${{ steps.create.outputs.cluster-id }}
+      cluster-endpoint: ${{ steps.create.outputs.cluster-endpoint }}
+      region: ${{ steps.create.outputs.region }}
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Create cluster
+        id: create
+        run: |
+          CLUSTER_NAME="${{ inputs.workflow_name }}-${{ github.run_id }}"
+          
+          for attempt in $(seq 1 $MAX_RETRIES); do
+            RESULT=$(aws dsql create-cluster \
+              --no-deletion-protection-enabled \
+              --tags "Name=$CLUSTER_NAME,Repo=${{ github.repository }},Type=integration-test" 2>&1) && break
+            BACKOFF=$((INITIAL_BACKOFF * attempt))
+            echo "Attempt $attempt failed, retrying in ${BACKOFF}s..."
+            sleep $BACKOFF
+          done
+          
+          CLUSTER_ID=$(echo "$RESULT" | jq -r '.identifier')
+          if [ -z "$CLUSTER_ID" ] || [ "$CLUSTER_ID" = "null" ]; then
+            echo "Failed to create cluster: $RESULT"
+            exit 1
+          fi
+          
+          echo "Waiting for cluster $CLUSTER_ID to become active..."
+          aws dsql wait cluster-active --identifier "$CLUSTER_ID"
+          
+          echo "cluster-id=$CLUSTER_ID" >> "$GITHUB_OUTPUT"
+          echo "cluster-endpoint=${CLUSTER_ID}.dsql.${{ env.AWS_REGION }}.on.aws" >> "$GITHUB_OUTPUT"
+          echo "region=${{ env.AWS_REGION }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/dsql-cluster-delete.yml
+++ b/.github/workflows/dsql-cluster-delete.yml
@@ -1,0 +1,38 @@
+name: Delete Aurora DSQL Cluster
+
+permissions: {}
+
+on:
+  workflow_call:
+    inputs:
+      cluster-id:
+        required: true
+        type: string
+        description: 'The cluster identifier to delete'
+      region:
+        required: true
+        type: string
+        description: 'The AWS region where the cluster exists'
+    secrets:
+      AWS_IAM_ROLE:
+        required: true
+
+jobs:
+  delete:
+    name: Delete Aurora DSQL Cluster
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write # required by aws-actions/configure-aws-credentials
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ inputs.region }}
+
+      - name: Delete cluster
+        run: |
+          echo "Deleting cluster ${{ inputs.cluster-id }}..."
+          aws dsql delete-cluster --identifier "${{ inputs.cluster-id }}" > /dev/null


### PR DESCRIPTION
This PR modifies the CI/CD workflow to create a cluster per workflow, which prevents conflicts between parallel runs.

This prevents frustrating behavior where GitHub cancels pending workflows when multiple PRs are being created or worked on at the same time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
